### PR TITLE
Update deprecated calls

### DIFF
--- a/Resources/templates/CommonAdmin/EditAction/update.php.twig
+++ b/Resources/templates/CommonAdmin/EditAction/update.php.twig
@@ -17,9 +17,9 @@
 
         $this->preBindRequest(${{ builder.ModelClass }});
         $form = $this->getEditForm(${{ builder.ModelClass }});
-        $form->bind($this->get('request'));
+        $form->handleRequest($this->get('request'));
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             try {
                 {% if concurrency_lock -%}
                 $versions = $this->getVersions();

--- a/Resources/templates/CommonAdmin/NewAction/create.php.twig
+++ b/Resources/templates/CommonAdmin/NewAction/create.php.twig
@@ -11,9 +11,9 @@
 
         $this->preBindRequest(${{ builder.ModelClass }});
         $form = $this->getNewForm(${{ builder.ModelClass }});
-        $form->bind($this->get('request'));
+        $form->handleRequest($this->get('request'));
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             try {
                 $this->preSave($form, ${{ builder.ModelClass }});
                 $this->saveObject(${{ builder.ModelClass }});


### PR DESCRIPTION
Replace `$form->submit($request)` calls by `$form->handleRequest($request)`
