### PR TITLE
More informative error messages for actions builder

### DIFF
--- a/Exception/ValidationException.php
+++ b/Exception/ValidationException.php
@@ -2,6 +2,43 @@
 
 namespace Admingenerator\GeneratorBundle\Exception;
 
+use Symfony\Component\Validator\ConstraintViolation;
+
 class ValidationException extends \LogicException
 {
+    /**
+     * @var ConstraintViolation[] An array of ConstraintViolation instances.
+     */
+    protected $errors;
+
+    /**
+     * @param ConstraintViolation[] $errors An array of ConstraintViolation instances.
+     */
+    public function __construct($errors = array())
+    {
+        $this->setErrors($errors);
+
+        parent::__construct();
+    }
+
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+
+    /**
+     * Validate and set errors.
+     * 
+     * @param ConstraintViolation[] $errors An array of ConstraintViolation instances.
+     */
+    public function setErrors($errors = array())
+    {
+        foreach ($errors as $error) {
+            if (!$error instanceof ConstraintViolation) {
+                throw new \InvalidArgumentException();
+            }
+        }
+
+        $this->errors = $errors;
+    }
 }

--- a/Resources/public/css/bootstrap-extended.css
+++ b/Resources/public/css/bootstrap-extended.css
@@ -76,6 +76,14 @@ button:hover > [class*=" fa-"]:before {
     background-image: none !important;
 }
 
+/* Remove wrap from dl-horizontal */
+.dl-horizontal.dl-actions-error {
+    margin-bottom: 0px;
+}
+.dl-horizontal.dl-actions-error dt {
+    white-space: normal;
+}
+
 /* Callouts from BS docs */
 /* Side notes for calling out things
 -------------------------------------------------- */

--- a/Resources/templates/CommonAdmin/ActionsAction/ActionsBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ActionsAction/ActionsBuilderAction.php.twig
@@ -135,4 +135,28 @@ class ActionsController extends BaseController
     {
         return preg_replace('/[^\w]+/', '', $method);
     }
+
+    /**
+     * Render errors as HTML DL list
+     *
+     * @param ValidationException $exception
+     * @param string $translationDomain
+     * @return string Raw HTML string
+     */
+    protected function renderErrorsAsHTML(ValidationException $exception, $translationDomain)
+    {
+        $html = '';
+
+        if (count($exception->getErrors()) > 0) {
+            $html = '<dl class="dl-horizontal dl-actions-error">';
+            foreach ($exception->getErrors() as $error) {
+                $label = $this->get('translator')->trans(ucfirst($error->getPropertyPath()), array(), $translationDomain);
+
+                $html .= '<dt>'.$label.'</dt><dd>'.$error->getMessage().'</dd>';
+            }
+            $html .= '</dl>';
+        }
+
+        return $html;
+    }
 }

--- a/Resources/templates/CommonAdmin/ActionsAction/object_action.php.twig
+++ b/Resources/templates/CommonAdmin/ActionsAction/object_action.php.twig
@@ -104,14 +104,15 @@
      */
     protected function errorObject{{ action.name|php_name|capitalize }}(\Exception $e, \{{ model }} ${{ builder.ModelClass }} = null)
     {
-        $this->get('session')->getFlashBag()->add(
-            'error',
-            $this->get('translator')->trans(
-                "{{ action.options.error|default("action.custom.error") }}",
-                array('%name%' => '{{ action.label }}'),
-                '{{ action.options.error is defined ? i18n_catalog|default("Admin") : 'Admingenerator' }}'
-            )
+        $header = $this->get('translator')->trans(
+            "{{ action.options.error|default("action.custom.error") }}",
+            array('%name%' => '{{ action.label }}'),
+            '{{ action.options.error is defined ? i18n_catalog|default("Admin") : 'Admingenerator' }}'
         );
+
+        $errors = $this->renderErrorsAsHTML($e, '{{ action.options.error is defined ? i18n_catalog|default("Admin") : "Admingenerator" }}');
+
+        $this->get('session')->getFlashBag()->add('error', $header.' '.$errors);
 
         return new RedirectResponse($this->generateUrl("{{ builder.routePrefixWithSubfolder }}_{{ bundle_name }}{{ builder.BaseGeneratorName ? "_" ~ builder.BaseGeneratorName : "" }}_list"));
     }

--- a/Resources/templates/Doctrine/ActionsBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/ActionsBuilderAction.php.twig
@@ -85,7 +85,7 @@
             if ($debug) {
                 $this->get('logger')->error((string) $errors);
             }
-            throw new ValidationException();
+            throw new ValidationException($errors);
         } else {
             $em = $this->getDoctrine()->getManagerForClass(get_class(${{ builder.ModelClass }}));
             $em->persist(${{ builder.ModelClass }});

--- a/Resources/templates/DoctrineODM/ActionsBuilderAction.php.twig
+++ b/Resources/templates/DoctrineODM/ActionsBuilderAction.php.twig
@@ -87,7 +87,7 @@
             if ($debug) {
                 $this->get('logger')->error((string) $errors);
             }
-            throw new ValidationException();
+            throw new ValidationException($errors);
         } else {
             $em = $this->getDocumentManager();
             $em->persist(${{ builder.ModelClass }});

--- a/Resources/templates/Propel/ActionsBuilderAction.php.twig
+++ b/Resources/templates/Propel/ActionsBuilderAction.php.twig
@@ -53,7 +53,7 @@
             if ($debug) {
                 $this->get('logger')->error((string) $errors);
             }
-            throw new ValidationException();
+            throw new ValidationException($errors);
         } else {
             ${{ builder.ModelClass }}->save();
         }


### PR DESCRIPTION
The goal of this PR is to append a list of Validation errors to the error message.
- Given action `accept` which changes `Document` entity and attemts to persist the change useing the default `saveObject` method.
- Assuming the validation fails, becouse `number` field is expected to be not empty and `reciever` should be at least 3 characters long.

The following Flash error message would be created:

Before this PR:

> Could not accept Document.

After this PR:

> Could not accept Document.
> 
>  number This field should not be blank.
>  reciever This field should contain at least 3 characters.

Note: _The exact error messages could be diffrent. This example is just to illustrate how the list of validation errors is appended to the original message._
