### PR TITLE
Fix optimistic lock exception on soft delete

### DIFF
--- a/Resources/templates/Doctrine/ActionsBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/ActionsBuilderAction.php.twig
@@ -55,8 +55,17 @@
     protected function executeObjectDelete(\{{ model }} ${{ builder.ModelClass }})
     {
         $em = $this->getDoctrine()->getManagerForClass('{{ model }}');
+        $cmf = $em->getMetadataFactory();
+        $class = $cmf->getMetadataFor('{{ model }}');
+        $isVersioned = $class->isVersioned;
+        if($isVersioned) {
+            $class->setVersioned(false); 
+        }
         $em->remove(${{ builder.ModelClass }});
         $em->flush();
+        if($isVersioned) {
+            $class->setVersioned(true);
+        }
         $em->clear();
     }
 


### PR DESCRIPTION
Avoid optimistic lock exception when soft-deleteable behaviour also enabled on entity
Without this patch impossible to "delete" entity (update deleted_at field) with enabled soft deleted doctrine behaviour and optimistic lock.
