### PR TITLE
[Feature] Add CSS class block on each row

### DIFF
--- a/Resources/templates/CommonAdmin/ListTemplate/RowBuilderTemplate.php.twig
+++ b/Resources/templates/CommonAdmin/ListTemplate/RowBuilderTemplate.php.twig
@@ -2,7 +2,7 @@
 
 {% block list_row %}
     {{ echo_block('list_row') }}
-        <tr role="row" class="list-results-fields-row">
+        <tr role="row" class="list-results-fields-row {{ echo_block('list_row_class') }}{{ echo_endblock() }}">
             {{- block('list_row_content') -}}
         </tr>
     {{ echo_endblock() }}


### PR DESCRIPTION
This is very nice feature. For example, you wanna mark with different background and foreground colour some of the rows in result table, based on your custom criteria. After this patch you can do it in a very simple way.
Just add the following code to your `rows.html.twig`:

```
{% block list_row_class %}{% if Object.needsToDrawInRed %}make-it-red{% endif %}{% endblock list_row_class %}
```

Also don't forget to add CSS rule:

```
.make-it-red td {
  background: red;
  color: white;
}
```

Or even you can generate CSS class(es) for table row dynamically from your object's function call:

```
{% block list_row_class %}{{ Object.getCssClassForTableRow }}{% endblock list_row_class %}
```
