### PR TITLE
Move jquery to scripts_head block

### DIFF
--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -29,7 +29,6 @@
 {% block javascripts %}
     {% javascripts package='admingenerator_js' filter='?uglifyjs2'
     output='assetic/js/compiled/admingenerator.min.js'
-        'admin/components/jquery/dist/jquery.js'
         'admin/components/bootstrap/dist/js/bootstrap.js'
         'admin/components/iCheck/icheck.js'
         'admin/components/slimScroll/jquery.slimscroll.js'

--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -16,9 +16,16 @@
 
 {% block scripts_head %}
     {% javascripts package='admingenerator_js' filter='?uglifyjs2'
+    output='assetic/js/compiled/jquery.min.js'
+        'admin/components/jquery/dist/jquery.js'
+    %}
+    <script type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
+
+    {% javascripts package='admingenerator_js' filter='?uglifyjs2'
     output='assetic/js/compiled/ie9.min.js'
-        'admin/components/html5shiv/dist/html5shiv.min.js'
-        'admin/components/respond/dest/respond.min.js'
+        'admin/components/html5shiv/dist/html5shiv.js'
+        'admin/components/respond/dest/respond.src.js'
     %}
     <!--[if lt IE 9]>
         <script type="text/javascript" src="{{ asset_url }}"></script>

--- a/Resources/views/base_uncompressed.html.twig
+++ b/Resources/views/base_uncompressed.html.twig
@@ -31,6 +31,7 @@
         {% endblock %}
 
         {% block javascripts_head %}
+            <script src="{{ asset("admin/components/jquery/dist/jquery.min.js") }}" type="text/javascript"></script>
             <!--[if lt IE 9]>
                 <script src="{{ asset('admin/components/html5shiv/dist/html5shiv.min.js') }}"></script>
                 <script src="{{ asset('admin/components/respond/dest/respond.min.js') }}"></script>
@@ -78,7 +79,6 @@
     {% endblock wrapper %}
 
     {% block javascripts %}
-        <script src="{{ asset("admin/components/jquery/dist/jquery.min.js") }}" type="text/javascript"></script>
         <script src="{{ asset("admin/components/bootstrap/dist/js/bootstrap.min.js") }}" type="text/javascript"></script>
         <script src="{{ asset("admin/components/iCheck/icheck.min.js") }}" type="text/javascript"></script>
         <script src="{{ asset("admin/components/slimScroll/jquery.slimscroll.min.js") }}" type="text/javascript"></script>


### PR DESCRIPTION
jQuery must be loaded in the head of the page, becouse some form widgets can use inline Javascript depending on jQuery.

Eg. `symfony2admingenerator/FormExtensionsBundle` has a lot `jQuery(document).ready(function { /* do smg here */ })` calls, which failed due to jQuery not being loaded first.