### PR TITLE
Replace classify with method to handle dots

### DIFF
--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -111,7 +111,7 @@ class ExcelController extends ListController
             $getter = 'get'.ucfirst($getter);
             $value = method_exists($data, $getter) ? $data->$getter() : null;
 
-            $formatedValue = $this->format{{ name|replace({".": "_"})|capitalize }}($value);
+            $formatedValue = $this->format{{ name|classify|php_name }}($value);
 
             // Convert DateTime object to given format
             if ($formatedValue instanceof \DateTime){
@@ -140,7 +140,7 @@ class ExcelController extends ListController
      * @param mixed The value
      * @return mixed The formated value
      */
-    protected function format{{ name|replace({".": "_"})|capitalize }}($value)
+    protected function format{{ name|classify|php_name }}($value)
     {
         return $value;
     }

--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -111,7 +111,7 @@ class ExcelController extends ListController
             $getter = 'get'.ucfirst($getter);
             $value = method_exists($data, $getter) ? $data->$getter() : null;
 
-            $formatedValue = $this->format{{ name|classify }}($value);
+            $formatedValue = $this->format{{ name|replace({".": "_"})|capitalize }}($value);
 
             // Convert DateTime object to given format
             if ($formatedValue instanceof \DateTime){
@@ -140,7 +140,7 @@ class ExcelController extends ListController
      * @param mixed The value
      * @return mixed The formated value
      */
-    protected function format{{ name|classify }}($value)
+    protected function format{{ name|replace({".": "_"})|capitalize }}($value)
     {
         return $value;
     }


### PR DESCRIPTION
The current implementation with `classify` does not work, as it does not translate dots in the name (which can be used to indicate relations). And as dots are not allowed in methods, it does not work. 

I've also added the capitalize filter such that the method still start with `formatSomething`. I would not use the classify filter anymore as it might result in conflicts with names.