### PR TITLE
Allow filtering on associations by setting them filterable

### DIFF
--- a/Guesser/DoctrineORMFieldGuesser.php
+++ b/Guesser/DoctrineORMFieldGuesser.php
@@ -37,6 +37,7 @@ class DoctrineORMFieldGuesser extends ContainerAware
         if (!$this->doctrine->getManagerForClass(self::$current_class)->getConfiguration()->getMetadataDriverImpl()->isTransient($class)) {
             $this->metadata[self::$current_class] = $this->doctrine->getManagerForClass(self::$current_class)->getClassMetadata($class);
         }
+        
         return $this->metadata[self::$current_class];
     }
 

--- a/Guesser/DoctrineORMFieldGuesser.php
+++ b/Guesser/DoctrineORMFieldGuesser.php
@@ -37,13 +37,12 @@ class DoctrineORMFieldGuesser extends ContainerAware
         if (!$this->doctrine->getManagerForClass(self::$current_class)->getConfiguration()->getMetadataDriverImpl()->isTransient($class)) {
             $this->metadata[self::$current_class] = $this->doctrine->getManagerForClass(self::$current_class)->getClassMetadata($class);
         }
-
         return $this->metadata[self::$current_class];
     }
 
     public function getAllFields($class)
     {
-        return $this->getMetadatas($class)->getFieldNames();
+        return array_merge($this->getMetadatas($class)->getFieldNames(), $this->getMetadatas($class)->getAssociationNames());
     }
 
     /**


### PR DESCRIPTION
When adding the property 'filterable' to columns, they will only appear under filters if they are a field of the Entity.
When there's an association present with the property 'filterable', it will not appear under filters even though filtering works fine.
This is due to the behavior of the `getAllFields` method in the FieldGuessers, which only returns fields and not associations.
This PR fixes this.