### PR TITLE
Fix error due to renamed variable in ExcelBuilder

### DIFF
--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -98,7 +98,7 @@ class ExcelController extends ListController
 
         {% set colNum = 0 %}
         foreach($results as $rowData) {
-            {% for name,column in builder.columns %}
+            {% for name,builder_column in builder.columns %}
             $data = $this->getValueForCell('{{ builder_column.getter }}', $rowData);
             $formatedValue = $this->format{{ name|classify|php_name }}($data);
 


### PR DESCRIPTION
An error was introduced in #122, where the column variable was renamed to builder_column, but just at one place. This fixes the other place as well, preventing errors.