### PR TITLE
FormOptions from config should override default options

### DIFF
--- a/Resources/templates/CommonAdmin/EditType/type.php.twig
+++ b/Resources/templates/CommonAdmin/EditType/type.php.twig
@@ -46,10 +46,10 @@ class {{ builder.YamlKey|ucfirst }}Type extends BaseType
         $optionsClass = '{{ builder.namespacePrefixWithSubfolder }}\{{ bundle_name }}\Form\Type\{{ builder.BaseGeneratorName }}\Options';
         $options = class_exists($optionsClass) ? new $optionsClass() : null;
 
-        return $this->resolveOptions('{{ column.name }}', {{ column.formOptions|merge({
+        return $this->resolveOptions('{{ column.name }}', {{ ({
             'label': column.label,
             'translation_domain': i18n_catalog|default('Admin')
-        })|as_php|convert_as_form(column.formType) }}, $builderOptions, $options);
+        })|merge(column.formOptions)|as_php|convert_as_form(column.formType) }}, $builderOptions, $options);
     }
 
     /**


### PR DESCRIPTION
I think merging of this two array should be turned around, since otherwise you can't overide for example translation domain from generator config.