### PR TITLE
Allow generate admin into default AppBundle (without namespace)

### DIFF
--- a/Command/GenerateAdminAdminCommand.php
+++ b/Command/GenerateAdminAdminCommand.php
@@ -236,7 +236,7 @@ EOT
             }
         }
 
-        $namespace = Validators::validateBundleNamespace($input->getOption('namespace'));
+        $namespace = Validators::validateBundleNamespace($input->getOption('namespace'), false);
         if (!$bundle = $input->getOption('bundle-name')) {
             $bundle = strtr($namespace, array('\\' => ''));
         }

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -85,7 +85,13 @@ class BundleGenerator extends BaseBundleGenerator
                 break;
         }
 
-        list( $namespace_prefix, $bundle_name) = explode('\\', $namespace, 2);
+        if (FALSE === strpos($namespace, '\\')) {
+            $bundle_name = $namespace;
+            $namespace_prefix = null;
+        } else {
+            list( $namespace_prefix, $bundle_name) = explode('\\', $namespace, 2);
+        }
+
         $parameters = array(
             'namespace'        => $namespace,
             'bundle'           => $bundle,


### PR DESCRIPTION
Usage: app/console admin:generate-admin --namespace=AppBundle --dir=src --format=annotation   
