### PR TITLE
Also set filters buttons to no display when defaultFiltersVisibility …

### DIFF
--- a/Resources/templates/CommonAdmin/ListTemplate/FiltersBuilderTemplate.php.twig
+++ b/Resources/templates/CommonAdmin/ListTemplate/FiltersBuilderTemplate.php.twig
@@ -43,7 +43,7 @@
                         {% endfor %}
                         {{ echo_twig("form_rest(form)") }}
                     </div>
-                    <div class="box-footer">
+                    <div class="box-footer"{% if builder.filtersMode == 'top' and builder.defaultFiltersVisibility == 'collapsed' %} style="display: none;"{% endif %}>
                         <div class="btn-toolbar">
                             <div class="pull-right">
                                 <button type="submit" class="btn btn-sm btn-primary"><i class="fa fa-search"></i> {{ echo_trans('list.button.filter') }}</button>


### PR DESCRIPTION
…is collapsed

When using the defaultFiltersVisibility = 'collapsed', the buttons are still shown.
This commit fixes that.