### PR TITLE
Grid class can be set in entity generator

### DIFF
--- a/Resources/templates/CommonAdmin/EditTemplate/fieldsets.php.twig
+++ b/Resources/templates/CommonAdmin/EditTemplate/fieldsets.php.twig
@@ -1,5 +1,6 @@
 {% block form_fieldsets %}
-    {% set gridClass = builder.variable('grid_class') %}
+    {% set gridClass = builder.variable('grid_class') | default('col-md-4') %}
+
     {% for fieldsetName,fieldset in builder.fieldsets %}
         {% set fieldsetColumns = builder.columnsFor(fieldset) %}
         {% set fieldsetGroups = fieldsetColumns|mapBy('groups')|flatten %}
@@ -16,7 +17,7 @@
                     {% endif %}
 
                     {% for rowName,row in fieldset %}
-                        {% set rowspan = gridClass ? gridClass : 'col-md-4' %}
+                        {% set rowspan = rowName|is_numeric ? gridClass : rowName %}
                         {% set rowColumns = builder.columnsFor(row) %}
                         {% set rowGroups = rowColumns|mapBy('groups')|flatten %}
 

--- a/Resources/templates/CommonAdmin/EditTemplate/fieldsets.php.twig
+++ b/Resources/templates/CommonAdmin/EditTemplate/fieldsets.php.twig
@@ -1,4 +1,5 @@
 {% block form_fieldsets %}
+    {% set gridClass = builder.variable('grid_class') %}
     {% for fieldsetName,fieldset in builder.fieldsets %}
         {% set fieldsetColumns = builder.columnsFor(fieldset) %}
         {% set fieldsetGroups = fieldsetColumns|mapBy('groups')|flatten %}
@@ -15,7 +16,7 @@
                     {% endif %}
 
                     {% for rowName,row in fieldset %}
-                        {% set rowspan = rowName|is_numeric ? 'col-md-4' : rowName %}
+                        {% set rowspan = gridClass ? gridClass : 'col-md-4' %}
                         {% set rowColumns = builder.columnsFor(row) %}
                         {% set rowGroups = rowColumns|mapBy('groups')|flatten %}
 


### PR DESCRIPTION
Grid class can be set in entity generator, which is then set in the view. If class is not set, default one (defined in template) is taken.

This can be used as workaround to quickly set custom grid class. Better solution would be that you can set default class globally (in config.yml), and also per field (maybe we can discuss this and find solution together). Order of priority would then be: Entity-generator.yml per field > Entity-generator.yml per builder > config.yml

In order to use this, you can define grid class under builders in generator file.
Example:

```yml
edit:
    params:
        title: "Custom title"
        display:
            - title
        actions:
            save: ~
            list: ~
        grid_class: "col-md-8"
```

Todo:
* I wanted to put this also in documentation, but didn't know where