### PR TITLE
Allow filter options, for better customization of filter types

### DIFF
--- a/Builder/Admin/BaseBuilder.php
+++ b/Builder/Admin/BaseBuilder.php
@@ -192,6 +192,8 @@ class BaseBuilder extends GenericBaseBuilder
 
             if (array_key_exists('addFilterOptions', $fieldOptions)) {
                 $column->setAddFilterOptions($fieldOptions['addFilterOptions']);
+            } elseif (array_key_exists('addFormOptions', $fieldOptions)) {
+                $column->setAddFilterOptions($fieldOptions['addFormOptions']);
             }
         }
 

--- a/Builder/Admin/BaseBuilder.php
+++ b/Builder/Admin/BaseBuilder.php
@@ -189,6 +189,10 @@ class BaseBuilder extends GenericBaseBuilder
             if (array_key_exists('addFormOptions', $fieldOptions)) {
                 $column->setAddFormOptions($fieldOptions['addFormOptions']);
             }
+
+            if (array_key_exists('addFilterOptions', $fieldOptions)) {
+                $column->setAddFilterOptions($fieldOptions['addFilterOptions']);
+            }
         }
 
         return $column;

--- a/Builder/Admin/BaseBuilder.php
+++ b/Builder/Admin/BaseBuilder.php
@@ -151,14 +151,18 @@ class BaseBuilder extends GenericBaseBuilder
 
             if ($this->getYamlKey() === 'list') {
                 // Filters
-                $column->setFormOptions($this->getFieldOption(
+                $column->setFilterOptions($this->getFieldOption(
                     $column,
-                    'formOptions',
-                    $this->getFieldGuesser()->getFormOptions(
-                        $column->getFilterType(),
-                        $filteredFieldDbType,
-                        $this->getVariable('model'),
-                        $column->getFilterOn()
+                    'filterOptions',
+                    $this->getFieldOption(
+                        $column,
+                        'formOptions',
+                        $this->getFieldGuesser()->getFilterOptions(
+                            $column->getFilterType(),
+                            $filteredFieldDbType,
+                            $this->getVariable('model'),
+                            $column->getFilterOn()
+                        )
                     )
                 ));
             } else {

--- a/Generator/Column.php
+++ b/Generator/Column.php
@@ -89,6 +89,11 @@ class Column
     protected $formOptions = array();
 
     /**
+     * @var array
+     */
+    protected $filterOptions = array();
+
+    /**
      * @var string
      */
     protected $getter;
@@ -310,6 +315,16 @@ class Column
         return $this->filterType;
     }
 
+    public function setFilterOptions($filterOptions)
+    {
+        $this->filterOptions = $filterOptions;
+    }
+
+    public function getFilterOptions()
+    {
+        return $this->filterOptions;
+    }
+
     public function setLocalizedDateFormat($localizedDateFormat)
     {
         $this->localizedDateFormat = $localizedDateFormat;
@@ -334,6 +349,13 @@ class Column
     {
         foreach ($additionalOptions as $name => $option) {
             $this->formOptions[$name] = $this->parseOption($option);
+        }
+    }
+
+    public function setAddFilterOptions(array $additionalOptions = array())
+    {
+        foreach ($additionalOptions as $name => $option) {
+           $this->filterOptions[$name] = $this->parseOption($option);
         }
     }
 

--- a/Generator/Column.php
+++ b/Generator/Column.php
@@ -149,8 +149,8 @@ class Column
     protected $debug = array();
 
     /**
-     * @param string  $name
-     * @param boolean $debug
+     * @param string $name
+     * @param array  $debug
      */
     public function __construct($name, $debug)
     {

--- a/Guesser/DoctrineODMFieldGuesser.php
+++ b/Guesser/DoctrineODMFieldGuesser.php
@@ -157,7 +157,39 @@ class DoctrineODMFieldGuesser extends ContainerAware
         );
     }
 
+    /**
+     * @param $formType
+     * @param $dbType
+     * @param $model
+     * @param $fieldPath
+     * @return array
+     */
     public function getFormOptions($formType, $dbType, $model, $fieldPath)
+    {
+        return $this->getOptions($formType, $dbType, $model, $fieldPath, false);
+    }
+
+    /**
+     * @param $filterType
+     * @param $dbType
+     * @param $model
+     * @param $fieldPath
+     * @return array
+     */
+    public function getFilterOptions($filterType, $dbType, $model, $fieldPath)
+    {
+        return $this->getOptions($filterType, $dbType, $model, $fieldPath, true);
+    }
+
+    /**
+     * @param      $type
+     * @param      $dbType
+     * @param      $model
+     * @param      $fieldPath
+     * @param bool $filter
+     * @return array
+     */
+    protected function getOptions($type, $dbType, $model, $fieldPath, $filter = false)
     {
         if ('virtual' === $dbType) {
             return array();
@@ -168,7 +200,7 @@ class DoctrineODMFieldGuesser extends ContainerAware
         $columnName = $resolved['field'];
 
         if ('boolean' == $dbType &&
-            (preg_match("#^choice#i", $formType) || preg_match("#choice$#i", $formType))) {
+            (preg_match("#^choice#i", $type) || preg_match("#choice$#i", $type))) {
             return array(
                 'choices' => array(
                    0 => 'boolean.no',
@@ -179,7 +211,7 @@ class DoctrineODMFieldGuesser extends ContainerAware
             );
         }
 
-        if (preg_match("#^document#i", $formType) || preg_match("#document$#i", $formType)) {
+        if (preg_match("#^document#i", $type) || preg_match("#document$#i", $type)) {
             $mapping = $this->getMetadatas($class)->getFieldMapping($columnName);
 
             return array(
@@ -188,7 +220,7 @@ class DoctrineODMFieldGuesser extends ContainerAware
             );
         }
 
-        if (preg_match("#^collection#i", $formType) || preg_match("#collection$#i", $formType)) {
+        if (preg_match("#^collection#i", $type) || preg_match("#collection$#i", $type)) {
             $mapping = $this->getMetadatas($class)->getFieldMapping($columnName);
 
             return array(
@@ -211,7 +243,7 @@ class DoctrineODMFieldGuesser extends ContainerAware
             );
         }
 
-        return array('required' => $this->isRequired($class, $columnName));
+        return array('required' => $filter ? false : $this->isRequired($class, $columnName));
     }
 
     protected function isRequired($class, $fieldName)

--- a/Guesser/DoctrineODMFieldGuesser.php
+++ b/Guesser/DoctrineODMFieldGuesser.php
@@ -212,7 +212,7 @@ class DoctrineODMFieldGuesser extends ContainerAware
         }
         
         if ('boolean' == $dbType &&
-            (preg_match("#^checkbox#i", $formType) || preg_match("#checkbox#i", $formType))) {
+            (preg_match("#^checkbox#i", $type) || preg_match("#checkbox#i", $type))) {
             return array(
                 'required' => false,
             );

--- a/Guesser/DoctrineORMFieldGuesser.php
+++ b/Guesser/DoctrineORMFieldGuesser.php
@@ -222,7 +222,7 @@ class DoctrineORMFieldGuesser extends ContainerAware
         }
         
         if ('boolean' == $dbType &&
-            (preg_match("#^checkbox#i", $formType) || preg_match("#checkbox#i", $formType))) {
+            (preg_match("#^checkbox#i", $type) || preg_match("#checkbox#i", $type))) {
             return array(
                 'required' => false,
             );

--- a/Guesser/DoctrineORMFieldGuesser.php
+++ b/Guesser/DoctrineORMFieldGuesser.php
@@ -174,6 +174,33 @@ class DoctrineORMFieldGuesser extends ContainerAware
      */
     public function getFormOptions($formType, $dbType, $model, $fieldPath)
     {
+        return $this->getOptions($formType, $dbType, $model, $fieldPath, false);
+    }
+
+    /**
+     * @param $filterType
+     * @param $dbType
+     * @param $model
+     * @param $fieldPath
+     * @return array
+     * @throws \Exception
+     */
+    public function getFilterOptions($filterType, $dbType, $model, $fieldPath)
+    {
+        return $this->getOptions($filterType, $dbType, $model, $fieldPath, true);
+    }
+
+    /**
+     * @param      $type
+     * @param      $dbType
+     * @param      $model
+     * @param      $fieldPath
+     * @param bool $filter
+     * @return array
+     * @throws \Exception
+     */
+    protected function getOptions($type, $dbType, $model, $fieldPath, $filter = false)
+    {
         if ('virtual' === $dbType) {
             return array();
         }
@@ -183,7 +210,7 @@ class DoctrineORMFieldGuesser extends ContainerAware
         $columnName = $resolved['field'];
 
         if ('boolean' == $dbType &&
-            (preg_match("#^choice#i", $formType) || preg_match("#choice$#i", $formType))) {
+            (preg_match("#^choice#i", $type) || preg_match("#choice$#i", $type))) {
             return array(
                 'choices' => array(
                     0 => 'boolean.no',
@@ -194,7 +221,7 @@ class DoctrineORMFieldGuesser extends ContainerAware
             );
         }
 
-        if ('number' === $formType) {
+        if ('number' === $type) {
             $mapping = $this->getMetadatas($class)->getFieldMapping($columnName);
 
             if (isset($mapping['scale'])) {
@@ -207,22 +234,22 @@ class DoctrineORMFieldGuesser extends ContainerAware
 
             return array(
                 'precision' => isset($precision) ? $precision : '',
-                'required'  => $this->isRequired($class, $columnName)
+                'required'  => $filter ? false : $this->isRequired($class, $columnName)
             );
         }
 
-        if (preg_match("#^entity#i", $formType) || preg_match("#entity$#i", $formType)) {
+        if (preg_match("#^entity#i", $type) || preg_match("#entity$#i", $type)) {
             $mapping = $this->getMetadatas($class)->getAssociationMapping($columnName);
 
             return array(
                 'multiple'      => ($mapping['type'] === ClassMetadataInfo::MANY_TO_MANY || $mapping['type'] === ClassMetadataInfo::ONE_TO_MANY),
                 'em'            => $this->getObjectManagerName($mapping['targetEntity']),
                 'class'         => $mapping['targetEntity'],
-                'required'      => $this->isRequired($class, $columnName),
+                'required'      => $filter ? false : $this->isRequired($class, $columnName),
             );
         }
 
-        if (preg_match("#^collection#i", $formType) || preg_match("#collection$#i", $formType)) {
+        if (preg_match("#^collection#i", $type) || preg_match("#collection$#i", $type)) {
             $mapping = $this->getMetadatas($class)->getAssociationMapping($columnName);
 
             return array(

--- a/Guesser/PropelORMFieldGuesser.php
+++ b/Guesser/PropelORMFieldGuesser.php
@@ -212,10 +212,36 @@ class PropelORMFieldGuesser extends ContainerAware
     /**
      * @param $formType
      * @param $dbType
-     * @param $columnName
+     * @param $model
+     * @param $fieldPath
      * @return array
      */
     public function getFormOptions($formType, $dbType, $model, $fieldPath)
+    {
+        return $this->getOptions($formType, $dbType, $model, $fieldPath, false);
+    }
+
+    /**
+     * @param $filterType
+     * @param $dbType
+     * @param $model
+     * @param $fieldPath
+     * @return array
+     */
+    public function getFilterOptions($filterType, $dbType, $model, $fieldPath)
+    {
+        return $this->getOptions($filterType, $dbType, $model, $fieldPath, true);
+    }
+
+    /**
+     * @param      $type
+     * @param      $dbType
+     * @param      $model
+     * @param      $fieldPath
+     * @param bool $filter
+     * @return array
+     */
+    protected function getOptions($type, $dbType, $model, $fieldPath, $filter = false)
     {
         if ('virtual' === $dbType) {
             return array();
@@ -226,7 +252,7 @@ class PropelORMFieldGuesser extends ContainerAware
         $columnName = $resolved['field'];
 
         if ((\PropelColumnTypes::BOOLEAN == $dbType || \PropelColumnTypes::BOOLEAN_EMU == $dbType) &&
-            (preg_match("#^choice#i", $formType) || preg_match("#choice$#i", $formType))) {
+            (preg_match("#^choice#i", $type) || preg_match("#choice$#i", $type))) {
             return array(
                 'choices' => array(
                    0 => 'boolean.no',
@@ -237,7 +263,7 @@ class PropelORMFieldGuesser extends ContainerAware
             );
         }
 
-        if (preg_match("#^model#i", $formType) || preg_match("#model$#i", $formType)) {
+        if (preg_match("#^model#i", $type) || preg_match("#model$#i", $type)) {
             $relation = $this->getRelation($columnName, $class);
             if ($relation) {
                 if (\RelationMap::MANY_TO_ONE === $relation->getType()) {
@@ -254,7 +280,7 @@ class PropelORMFieldGuesser extends ContainerAware
             }
         }
 
-        if (preg_match("#^collection#i", $formType) || preg_match("#collection$#i", $formType)) {
+        if (preg_match("#^collection#i", $type) || preg_match("#collection$#i", $type)) {
             $relation = $this->getRelation($columnName, $class);
 
             return array(
@@ -272,12 +298,12 @@ class PropelORMFieldGuesser extends ContainerAware
             $valueSet = $this->getMetadatas($class)->getColumn($class, $columnName)->getValueSet();
 
             return array(
-                'required' => $this->isRequired($class, $columnName),
+                'required' => $filter ? false : $this->isRequired($class, $columnName),
                 'choices'  => array_combine($valueSet, $valueSet),
             );
         }
 
-        return array('required' => $this->isRequired($class, $columnName));
+        return array('required' => $filter ? false : $this->isRequired($class, $columnName));
     }
 
     protected function isRequired($class, $fieldName)

--- a/Resources/templates/CommonAdmin/FiltersType/type.php.twig
+++ b/Resources/templates/CommonAdmin/FiltersType/type.php.twig
@@ -49,7 +49,7 @@ class FiltersType extends BaseType
                     'label': column.label,
                     'translation_domain': i18n_catalog|default('Admin'),
                     'required': false
-                }|merge(column.filterOptions ? column.filterOptions : column.formOptions)|as_php|convert_as_form(column.filterType) }}, $builderOptions, $options
+                }|merge(column.filterOptions)|as_php|convert_as_form(column.filterType) }}, $builderOptions, $options
             );
         }
 

--- a/Resources/templates/CommonAdmin/FiltersType/type.php.twig
+++ b/Resources/templates/CommonAdmin/FiltersType/type.php.twig
@@ -49,7 +49,7 @@ class FiltersType extends BaseType
                     'label': column.label,
                     'translation_domain': i18n_catalog|default('Admin'),
                     'required': false
-                }|merge(column.formOptions)|as_php|convert_as_form(column.formType) }}, $builderOptions, $options
+                }|merge(column.filterOptions ? column.filterOptions : column.formOptions)|as_php|convert_as_form(column.filterType) }}, $builderOptions, $options
             );
         }
 

--- a/Tests/Generator/ColumnTest.php
+++ b/Tests/Generator/ColumnTest.php
@@ -61,26 +61,25 @@ class ColumnTest extends TestCase
         }
     }
 
-    public function testSetAddFilterOptionsPhpFunction()
+    public function testSetAddFormFilterOptionsPhpFunction()
     {
         $column = new Column("test", false);
 
-        $column->setAddFilterOptions(array('years' => array('.range' => array('from' => 1900, 'to' => 1915, 'step' => 5))));
+        $addOptions = array('years' => array('.range' => array('from' => 1900, 'to' => 1915, 'step' => 5)));
 
-        $options = $column->getFilterOptions();
-
-        $this->assertEquals(array(1900, 1905, 1910, 1915), $options['years']);
-    }
-
-    public function testSetAddFormOptionsPhpFunction()
-    {
-        $column = new Column("test", false);
-
-        $column->setAddFormOptions(array('years' => array('.range' => array('from' => 1900, 'to' => 1915, 'step'=> 5 ))));
+        $column->setAddFormOptions($addOptions);
 
         $options = $column->getFormOptions();
 
-        $this->assertEquals(array(1900, 1905, 1910, 1915), $options['years']);
+        $testOptions = array(1900, 1905, 1910, 1915);
+
+        $this->assertEquals($testOptions, $options['years']);
+
+        $column->setAddFilterOptions($addOptions);
+
+        $options = $column->getFilterOptions();
+
+        $this->assertEquals($testOptions, $options['years']);
     }
 
     public function testFiltersGroups()

--- a/Tests/Generator/ColumnTest.php
+++ b/Tests/Generator/ColumnTest.php
@@ -49,6 +49,8 @@ class ColumnTest extends TestCase
             'dbType' => 'text',
             'formType' => 'choices',
             'formOptions' => array('foo' => 'bar'),
+            'filterType' => 'choice',
+            'filterOptions' => array('bar' => 'foo'),
         );
 
         $column = new Column("test", false);
@@ -57,6 +59,17 @@ class ColumnTest extends TestCase
             $column->setProperty($option, $value);
             $this->assertEquals($value, call_user_func_array(array($column, 'get'.Inflector::classify($option)), array()));
         }
+    }
+
+    public function testSetAddFilterOptionsPhpFunction()
+    {
+        $column = new Column("test", false);
+
+        $column->setAddFilterOptions(array('years' => array('.range' => array('from' => 1900, 'to' => 1915, 'step' => 5))));
+
+        $options = $column->getFilterOptions();
+
+        $this->assertEquals(array(1900, 1905, 1910, 1915), $options['years']);
     }
 
     public function testSetAddFormOptionsPhpFunction()


### PR DESCRIPTION
I'd like to differentiate my filter options from my form options, as it makes not much sense to have the same options for the filter type as the form type.
This PR should not break BC, as form options is used if filter options is empty.