### PR TITLE
Support empty string filtering in scopes

### DIFF
--- a/QueryFilter/DoctrineQueryFilter.php
+++ b/QueryFilter/DoctrineQueryFilter.php
@@ -59,11 +59,16 @@ class DoctrineQueryFilter extends BaseQueryFilter
      */
     public function addStringFilter($field, $value)
     {
+
         list($tableAlias, $filteredField) = $this->addTablePathToField($field);
 
         $paramName = $this->getParamName($tableAlias.'_'.$filteredField);
         $this->query->andWhere(sprintf('%s.%s LIKE :%s', $tableAlias, $filteredField, $paramName));
-        $this->query->setParameter($paramName, '%'.$value.'%');
+        if ($value === '') {
+            $this->query->setParameter($paramName, '');
+        } else {
+            $this->query->setParameter($paramName, '%' . $value . '%');
+        }
     }
 
     /**


### PR DESCRIPTION
In the special case of wanting to filter on an empty string in scopes, this doesn't work due to the added % signs in the query filter.
This PR fixes that for Doctrine ORM.