### PR TITLE
Updated FieldGuesser for boolean/checkbox combination

### DIFF
--- a/Guesser/DoctrineODMFieldGuesser.php
+++ b/Guesser/DoctrineODMFieldGuesser.php
@@ -178,6 +178,13 @@ class DoctrineODMFieldGuesser extends ContainerAware
                 'translation_domain' => 'Admingenerator'
             );
         }
+        
+        if ('boolean' == $dbType &&
+            (preg_match("#^checkbox#i", $formType) || preg_match("#checkbox#i", $formType))) {
+            return array(
+                'required' => false,
+            );
+        }
 
         if (preg_match("#^document#i", $formType) || preg_match("#document$#i", $formType)) {
             $mapping = $this->getMetadatas($class)->getFieldMapping($columnName);

--- a/Guesser/DoctrineORMFieldGuesser.php
+++ b/Guesser/DoctrineORMFieldGuesser.php
@@ -195,7 +195,7 @@ class DoctrineORMFieldGuesser extends ContainerAware
         }
         
         if ('boolean' == $dbType &&
-          (preg_match("#^checkbox#i", $formType) || preg_match("#checkbox#i", $formType))) {
+            (preg_match("#^checkbox#i", $formType) || preg_match("#checkbox#i", $formType))) {
             return array(
                 'required' => false,
             );

--- a/Guesser/DoctrineORMFieldGuesser.php
+++ b/Guesser/DoctrineORMFieldGuesser.php
@@ -193,6 +193,13 @@ class DoctrineORMFieldGuesser extends ContainerAware
                 'translation_domain' => 'Admingenerator'
             );
         }
+        
+        if ('boolean' == $dbType &&
+          (preg_match("#^checkbox#i", $formType) || preg_match("#checkbox#i", $formType))) {
+            return array(
+                'required' => false,
+            );
+        }
 
         if ('number' === $formType) {
             $mapping = $this->getMetadatas($class)->getFieldMapping($columnName);

--- a/Guesser/PropelORMFieldGuesser.php
+++ b/Guesser/PropelORMFieldGuesser.php
@@ -237,6 +237,13 @@ class PropelORMFieldGuesser extends ContainerAware
             );
         }
 
+        if ((\PropelColumnTypes::BOOLEAN == $dbType || \PropelColumnTypes::BOOLEAN_EMU == $dbType) &&
+            (preg_match("#^checkbox#i", $formType) || preg_match("#checkbox#i", $formType))) {
+            return array(
+                'required' => false
+            );
+        }
+
         if (preg_match("#^model#i", $formType) || preg_match("#model$#i", $formType)) {
             $relation = $this->getRelation($columnName, $class);
             if ($relation) {


### PR DESCRIPTION
I encountered the following problem:

When using a boolean field, which is not nullable in the database, the field guesser decides that the 
field is required, as it is not nullable.

However, as it is rendered as checkbox, the field should not be required, as then the browser forces it to be checked before a submit can be done.

I guess the best solution (if I am not missing anything) is to add another case to the Guesser, which detects a boolean and a checkbox form type. It should then just return the array('required' => false). That is what this PR does, for every manager (ORM, ODM and Propel). 