### PR TITLE
[BC Break] Remove deprecated calls and services

### DIFF
--- a/Builder/Generator.php
+++ b/Builder/Generator.php
@@ -59,7 +59,7 @@ class Generator extends TwigGeneratorGenerator
     public function __construct($cacheDir, $yaml)
     {
         parent::__construct($cacheDir);
-        $this->setYamlConfig(Yaml::parse($yaml));
+        $this->setYamlConfig(Yaml::parse(file_get_contents($yaml)));
     }
 
     /**
@@ -354,7 +354,7 @@ class Generator extends TwigGeneratorGenerator
     protected function setYamlConfig(array $yaml)
     {
         $this->yaml = array_replace_recursive(
-            Yaml::parse(__DIR__.'/../Resources/config/default.yml'),
+            Yaml::parse(file_get_contents(__DIR__.'/../Resources/config/default.yml')),
             $yaml
         );
     }

--- a/CacheWarmer/GeneratorCacheWarmer.php
+++ b/CacheWarmer/GeneratorCacheWarmer.php
@@ -78,7 +78,7 @@ class GeneratorCacheWarmer implements CacheWarmerInterface
 
     protected function parseYaml($file)
     {
-        $this->yaml_datas = Yaml::parse($file);
+        $this->yaml_datas = Yaml::parse(file_get_contents($file));
     }
 
 }

--- a/Controller/Doctrine/BaseController.php
+++ b/Controller/Doctrine/BaseController.php
@@ -3,6 +3,7 @@
 namespace Admingenerator\GeneratorBundle\Controller\Doctrine;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * A base controller for Doctrine
@@ -12,4 +13,8 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
  */
 abstract class BaseController extends Controller
 {
+    /**
+     * @var Request
+     */
+    protected $request;
 }

--- a/Controller/DoctrineODM/BaseController.php
+++ b/Controller/DoctrineODM/BaseController.php
@@ -3,6 +3,7 @@
 namespace Admingenerator\GeneratorBundle\Controller\DoctrineODM;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * A base controller for DoctrineODM
@@ -12,6 +13,11 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
  */
 abstract class BaseController extends Controller
 {
+    /**
+     * @var Request
+     */
+    protected $request;
+
     /**
      * @return \Doctrine\Bundle\MongoDBBundle\ManagerRegistry
      */

--- a/Controller/Propel/BaseController.php
+++ b/Controller/Propel/BaseController.php
@@ -3,6 +3,7 @@
 namespace Admingenerator\GeneratorBundle\Controller\Propel;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * A base controller for Propel
@@ -12,4 +13,8 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
  */
 abstract class BaseController extends Controller
 {
+    /**
+     * @var Request
+     */
+    protected $request;
 }

--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -83,7 +83,7 @@ class ControllerListener
     protected function getGenerator($generatorYaml)
     {
         if (!$generatorName = $this->cacheProvider->fetch($this->getCacheKey($generatorYaml.'_generator'))) {
-            $yamlParsed = Yaml::parse($generatorYaml);
+            $yamlParsed = Yaml::parse(file_get_contents($generatorYaml));
             $this->cacheProvider->save($this->getCacheKey($generatorYaml.'_generator'), $generatorName = $yamlParsed['generator']);
         }
 

--- a/Form/BaseType.php
+++ b/Form/BaseType.php
@@ -3,7 +3,7 @@
 namespace Admingenerator\GeneratorBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
@@ -31,16 +31,14 @@ abstract class BaseType extends AbstractType
         $this->authorizationChecker = $authorizationChecker;
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'groups' => array(),
             'cascade_validation' => true
         ));
 
-        $resolver->setAllowedTypes(array(
-            'groups' => 'array',
-        ));
+        $resolver->setAllowedTypes('groups', array('array'));
     }
 
     /**

--- a/Form/BaseType.php
+++ b/Form/BaseType.php
@@ -4,7 +4,7 @@ namespace Admingenerator\GeneratorBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Symfony\Component\Security\Core\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * Base class for new and edit forms.

--- a/Form/BaseType.php
+++ b/Form/BaseType.php
@@ -4,7 +4,7 @@ namespace Admingenerator\GeneratorBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\AuthorizationCheckerInterface;
 
 /**
  * Base class for new and edit forms.
@@ -14,18 +14,21 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
 abstract class BaseType extends AbstractType
 {
     /**
-     * @var SecurityContextInterface
+     * @var AuthorizationCheckerInterface
      */
-    protected $securityContext;
+    protected $authorizationChecker;
 
     /**
      * @var array
      */
     protected $groups = array();
 
-    public function setSecurityContext(SecurityContextInterface $securityContext)
+    /**
+     * @param AuthorizationCheckerInterface $authorizationChecker
+     */
+    public function setAuthorizationChecker(AuthorizationCheckerInterface $authorizationChecker)
     {
-        $this->securityContext = $securityContext;
+        $this->authorizationChecker = $authorizationChecker;
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
@@ -63,8 +66,8 @@ abstract class BaseType extends AbstractType
      */
     protected function inject($formType)
     {
-        if (is_object($formType) && method_exists($formType, 'setSecurityContext')) {
-            $formType->setSecurityContext($this->securityContext);
+        if (is_object($formType) && method_exists($formType, 'setAuthorizationChecker')) {
+            $formType->setAuthorizationChecker($this->authorizationChecker);
         }
 
         return $formType;
@@ -84,8 +87,8 @@ abstract class BaseType extends AbstractType
         $getter = 'get'.ucfirst($name).'Options';
 
         if ($optionsClass) {
-            if (method_exists($optionsClass, 'setSecurityContext')) {
-                $optionsClass->setSecurityContext($this->securityContext);
+            if (method_exists($optionsClass, 'setAuthorizationChecker')) {
+                $optionsClass->setAuthorizationChecker($this->authorizationChecker);
             }
 
             if (method_exists($optionsClass, $getter)) {

--- a/Menu/AdmingeneratorMenuBuilder.php
+++ b/Menu/AdmingeneratorMenuBuilder.php
@@ -89,6 +89,8 @@ class AdmingeneratorMenuBuilder extends ContainerAware
      */
     protected function isCurrentUri($uri)
     {
-        return $this->container->get('request')->getBaseUrl().$this->container->get('request')->getPathInfo() === $uri;
+        $request = $this->container->get('request_stack')->getCurrentRequest();
+
+        return $request->getBaseUrl().$request->getPathInfo() === $uri;
     }
 }

--- a/Resources/templates/CommonAdmin/ActionsAction/ActionsBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ActionsAction/ActionsBuilderAction.php.twig
@@ -37,8 +37,9 @@ class ActionsController extends BaseController
      */
     public function batchAction()
     {
-        $action = $this->get('request')->get('action');
-        $selected = $this->get('request')->get('selected');
+        $request = $this->getRequest();
+        $action = $request->get('action');
+        $selected = $request->get('selected');
 
         if (!$selected || !$action) {
             $this->get('session')->getFlashBag()->add(

--- a/Resources/templates/CommonAdmin/ActionsAction/ActionsBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ActionsAction/ActionsBuilderAction.php.twig
@@ -12,6 +12,7 @@ use {{ builder.generator.baseController }} as BaseController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Admingenerator\GeneratorBundle\Exception\ValidationException;
+use Symfony\Component\HttpFoundation\Request;
 
 {{ block('csrf_protection_use') }}
 
@@ -22,8 +23,9 @@ class ActionsController extends BaseController
     /**
      * Call custom object action based on $action parameter
      */
-    public function objectAction($pk, $action)
+    public function objectAction(Request $request, $pk, $action)
     {
+        $this->request = $request;
         $methodName = 'attemptObject'.ucfirst(strtolower($this->cleanMethodName($action)));
         if (!method_exists($this, $methodName)) {
             throw new NotFoundHttpException(sprintf('Undefined "%s" method. Does object action "%s" exist in your generator file?', $methodName, $action));
@@ -35,9 +37,9 @@ class ActionsController extends BaseController
     /**
      * Call custom batch action based on $action parameter
      */
-    public function batchAction()
+    public function batchAction(Request $request)
     {
-        $request = $this->getRequest();
+        $this->request = $request;
         $action = $request->get('action');
         $selected = $request->get('selected');
 

--- a/Resources/templates/CommonAdmin/ActionsAction/object_action.php.twig
+++ b/Resources/templates/CommonAdmin/ActionsAction/object_action.php.twig
@@ -20,7 +20,7 @@
             {{ block('security_action_with_object') -}}
 
             {%- if action.csrfProtected %}
-            if ('POST' == $this->getRequest()->getMethod()) {
+            if ('POST' == $this->request->getMethod()) {
                 {{ block('csrf_action_check_token') }}
 
                 $this->executeObject{{ action.name|php_name|capitalize }}(${{ builder.ModelClass }});

--- a/Resources/templates/CommonAdmin/ActionsAction/object_action.php.twig
+++ b/Resources/templates/CommonAdmin/ActionsAction/object_action.php.twig
@@ -20,7 +20,7 @@
             {{ block('security_action_with_object') -}}
 
             {%- if action.csrfProtected %}
-            if ('POST' == $this->get('request')->getMethod()) {
+            if ('POST' == $this->getRequest()->getMethod()) {
                 {{ block('csrf_action_check_token') }}
 
                 $this->executeObject{{ action.name|php_name|capitalize }}(${{ builder.ModelClass }});

--- a/Resources/templates/CommonAdmin/ActionsAction/object_delete.php.twig
+++ b/Resources/templates/CommonAdmin/ActionsAction/object_delete.php.twig
@@ -19,7 +19,7 @@
         try {
             {{ block('security_action_with_object') -}}
 
-            if ('POST' == $this->get('request')->getMethod()) {
+            if ('POST' == $this->getRequest()->getMethod()) {
                 {{ block('csrf_action_check_token') }}
 
                 $this->executeObjectDelete(${{ builder.ModelClass }});

--- a/Resources/templates/CommonAdmin/ActionsAction/object_delete.php.twig
+++ b/Resources/templates/CommonAdmin/ActionsAction/object_delete.php.twig
@@ -19,7 +19,7 @@
         try {
             {{ block('security_action_with_object') -}}
 
-            if ('POST' == $this->getRequest()->getMethod()) {
+            if ('POST' == $this->request->getMethod()) {
                 {{ block('csrf_action_check_token') }}
 
                 $this->executeObjectDelete(${{ builder.ModelClass }});

--- a/Resources/templates/CommonAdmin/EditAction/EditBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/EditAction/EditBuilderAction.php.twig
@@ -35,7 +35,7 @@ class EditController extends BaseController
     protected function getEditType()
     {
         $type = new EditType();
-        $type->setSecurityContext($this->get('security.context'));
+        $type->setAuthorizationChecker($this->get('security.authorization_checker'));
 
         return $type;
     }

--- a/Resources/templates/CommonAdmin/EditAction/EditBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/EditAction/EditBuilderAction.php.twig
@@ -7,6 +7,7 @@ namespace Admingenerated\{{ namespace_prefix }}{{ bundle_name }}\{{ builder.gene
 
 use {{ builder.generator.baseController }} as BaseController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 {% block orm_use %}{% endblock %}
 

--- a/Resources/templates/CommonAdmin/EditAction/index.php.twig
+++ b/Resources/templates/CommonAdmin/EditAction/index.php.twig
@@ -6,8 +6,10 @@ use {{ builder.namespacePrefixWithSubfolder }}\{{ bundle_name }}\Form\Type\{{ bu
 
 {% block index %}
 
-    public function indexAction($pk)
+    public function indexAction(Request $request, $pk)
     {
+        $this->request = $request;
+
         ${{ builder.ModelClass }} = $this->getObject($pk);
 
         {% if concurrency_lock -%}

--- a/Resources/templates/CommonAdmin/EditAction/update.php.twig
+++ b/Resources/templates/CommonAdmin/EditAction/update.php.twig
@@ -17,7 +17,9 @@
 
         $this->preBindRequest(${{ builder.ModelClass }});
         $form = $this->getEditForm(${{ builder.ModelClass }});
-        $form->handleRequest($this->get('request'));
+        $request = $this->getRequest();
+
+        $form->handleRequest($request);
         $this->postBindRequest($form, ${{ builder.ModelClass }});
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -35,11 +37,11 @@
 
                 {% set defaultActionAfterSave = builder.generator.bundleConfig.default_action_after_save %}
                 $actionAfterSave = "{{ actionAfterSave|default(defaultActionAfterSave) }}";
-                if ($this->get('request')->request->has('save-and-add') || ('new' == $actionAfterSave)) {
+                if ($request->request->has('save-and-add') || ('new' == $actionAfterSave)) {
                     return new RedirectResponse($this->getNewUrl());
-                } else if ($this->get('request')->request->has('save-and-list') || ('list' == $actionAfterSave)) {
+                } elseif ($request->request->has('save-and-list') || ('list' == $actionAfterSave)) {
                     return new RedirectResponse($this->getListUrl());
-                } else if ($this->get('request')->request->has('save-and-show') || ('show' == $actionAfterSave)) {
+                } elseif ($request->request->has('save-and-show') || ('show' == $actionAfterSave)) {
                     return new RedirectResponse($this->getShowUrl($pk));
                 } else {
                     if (('edit' != $actionAfterSave) &&

--- a/Resources/templates/CommonAdmin/EditAction/update.php.twig
+++ b/Resources/templates/CommonAdmin/EditAction/update.php.twig
@@ -5,8 +5,9 @@
 
 {% block update %}
 
-    public function updateAction($pk)
+    public function updateAction(Request $request, $pk)
     {
+        $this->request = $request;
         ${{ builder.ModelClass }} = $this->getObject($pk);
 
         {{ block('security_action_with_object') }}
@@ -17,7 +18,6 @@
 
         $this->preBindRequest(${{ builder.ModelClass }});
         $form = $this->getEditForm(${{ builder.ModelClass }});
-        $request = $this->getRequest();
 
         $form->handleRequest($request);
         $this->postBindRequest($form, ${{ builder.ModelClass }});

--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -9,6 +9,7 @@ namespace Admingenerated\{{ namespace_prefix }}{{ bundle_name }}\{{ builder.gene
 
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
@@ -20,8 +21,9 @@ class ExcelController extends ListController
      * Generates the Excel object and send a streamed response
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function excelAction()
+    public function excelAction(Request $request)
     {
+        $this->request = $request;
         {{ block('security_action') }}
         
         // Create the PHPExcel object with some standard values

--- a/Resources/templates/CommonAdmin/ListAction/ListBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ListAction/ListBuilderAction.php.twig
@@ -170,7 +170,7 @@ class ListController extends BaseController
     protected function getFiltersType()
     {
         $type = new FiltersType();
-        $type->setSecurityContext($this->get('security.context'));
+        $type->setAuthorizationChecker($this->get('security.authorization_checker'));
 
         return $type;
     }

--- a/Resources/templates/CommonAdmin/ListAction/ListBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ListAction/ListBuilderAction.php.twig
@@ -16,6 +16,7 @@ namespace Admingenerated\{{ namespace_prefix }}{{ bundle_name }}\{{ builder.gene
 use {{ builder.generator.baseController }} as BaseController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 use Pagerfanta\Pagerfanta;
 {% block pager_adapter -%}

--- a/Resources/templates/CommonAdmin/ListAction/filters.php.twig
+++ b/Resources/templates/CommonAdmin/ListAction/filters.php.twig
@@ -11,7 +11,7 @@
 
         if ($this->getRequest()->getMethod() == "POST") {
             $form = $this->getFilterForm();
-            $form->bind($this->getRequest());
+            $form->handleRequest($this->getRequest());
 
             if ($form->isValid()) {
                 $filters = $form->getViewData();

--- a/Resources/templates/CommonAdmin/ListAction/filters.php.twig
+++ b/Resources/templates/CommonAdmin/ListAction/filters.php.twig
@@ -1,7 +1,8 @@
 {% block filters %}
-    public function filtersAction()
+    public function filtersAction(Request $request)
     {
-        if ($this->getRequest()->get('reset')) {
+        $this->request = $request;
+        if ($this->request->get('reset')) {
             $this->setFilters(array());
             // Remove scopes and re-apply default ones
             $this->setScopes(null);
@@ -9,17 +10,17 @@
             return new RedirectResponse($this->getListUrl());
         }
 
-        if ($this->getRequest()->getMethod() == "POST") {
+        if ($this->request->getMethod() == "POST") {
             $form = $this->getFilterForm();
-            $form->handleRequest($this->getRequest());
+            $form->handleRequest($this->request);
 
             if ($form->isValid()) {
                 $filters = $form->getViewData();
             }
         }
 
-        if ($this->getRequest()->getMethod() == "GET") {
-            $filters = $this->getRequest()->query->all();
+        if ('GET' == $this->request->getMethod()) {
+            $filters = $this->request->query->all();
 
             {% for filter,column in builder.filterColumns %}
                 {% if column.filtersGroups %}

--- a/Resources/templates/CommonAdmin/ListAction/filters.php.twig
+++ b/Resources/templates/CommonAdmin/ListAction/filters.php.twig
@@ -1,7 +1,7 @@
 {% block filters %}
     public function filtersAction()
     {
-        if ($this->get('request')->get('reset')) {
+        if ($this->getRequest()->get('reset')) {
             $this->setFilters(array());
             // Remove scopes and re-apply default ones
             $this->setScopes(null);
@@ -11,7 +11,7 @@
 
         if ($this->getRequest()->getMethod() == "POST") {
             $form = $this->getFilterForm();
-            $form->bind($this->get('request'));
+            $form->bind($this->getRequest());
 
             if ($form->isValid()) {
                 $filters = $form->getViewData();

--- a/Resources/templates/CommonAdmin/ListAction/index.php.twig
+++ b/Resources/templates/CommonAdmin/ListAction/index.php.twig
@@ -6,8 +6,9 @@ use {{ builder.namespacePrefixWithSubfolder }}\{{ bundle_name }}\Form\Type\{{ bu
 
 {% block index %}
 
-    public function indexAction()
+    public function indexAction(Request $request)
     {
+        $this->request = $request;
         {{ block('security_action') }}
 
         $this->parseRequestForPager();

--- a/Resources/templates/CommonAdmin/ListAction/pager.php.twig
+++ b/Resources/templates/CommonAdmin/ListAction/pager.php.twig
@@ -5,16 +5,16 @@
      */
     protected function parseRequestForPager()
     {
-        if ($this->getRequest()->query->get('page')) {
-            $this->setPage($this->getRequest()->query->get('page'));
+        if ($this->request->query->get('page')) {
+            $this->setPage($this->request->query->get('page'));
         }
 
-        if ($this->getRequest()->query->get('perPage')) {
-            $this->setPerPage($this->getRequest()->query->get('perPage'));
+        if ($this->request->query->get('perPage')) {
+            $this->setPerPage($this->request->query->get('perPage'));
         }
 
-        if ($this->getRequest()->query->get('sort')) {
-            $this->setSort($this->getRequest()->query->get('sort'), $this->getRequest()->query->get('order_by','ASC'));
+        if ($this->request->query->get('sort')) {
+            $this->setSort($this->request->query->get('sort'), $this->request->query->get('order_by','ASC'));
         }
     }
 

--- a/Resources/templates/CommonAdmin/ListAction/pager.php.twig
+++ b/Resources/templates/CommonAdmin/ListAction/pager.php.twig
@@ -5,16 +5,16 @@
      */
     protected function parseRequestForPager()
     {
-        if ($this->get('request')->query->get('page')) {
-            $this->setPage($this->get('request')->query->get('page'));
+        if ($this->getRequest()->query->get('page')) {
+            $this->setPage($this->getRequest()->query->get('page'));
         }
 
-        if ($this->get('request')->query->get('perPage')) {
-            $this->setPerPage($this->get('request')->query->get('perPage'));
+        if ($this->getRequest()->query->get('perPage')) {
+            $this->setPerPage($this->getRequest()->query->get('perPage'));
         }
 
-        if ($this->get('request')->query->get('sort')) {
-            $this->setSort($this->get('request')->query->get('sort'), $this->get('request')->query->get('order_by','ASC'));
+        if ($this->getRequest()->query->get('sort')) {
+            $this->setSort($this->getRequest()->query->get('sort'), $this->getRequest()->query->get('order_by','ASC'));
         }
     }
 

--- a/Resources/templates/CommonAdmin/ListAction/scopes.php.twig
+++ b/Resources/templates/CommonAdmin/ListAction/scopes.php.twig
@@ -1,7 +1,7 @@
 {% block scopes %}
     public function scopesAction()
     {
-        $this->setScope($this->get('request')->get('group'), $this->get('request')->get('scope'));
+        $this->setScope($this->getRequest()->get('group'), $this->getRequest()->get('scope'));
 
         return new RedirectResponse($this->getListUrl());
     }

--- a/Resources/templates/CommonAdmin/ListAction/scopes.php.twig
+++ b/Resources/templates/CommonAdmin/ListAction/scopes.php.twig
@@ -1,7 +1,8 @@
 {% block scopes %}
-    public function scopesAction()
+    public function scopesAction(Request $request)
     {
-        $this->setScope($this->getRequest()->get('group'), $this->getRequest()->get('scope'));
+        $this->request = $request;
+        $this->setScope($this->request->get('group'), $this->request->get('scope'));
 
         return new RedirectResponse($this->getListUrl());
     }

--- a/Resources/templates/CommonAdmin/NestedListAction/NestedListBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/NestedListAction/NestedListBuilderAction.php.twig
@@ -12,6 +12,7 @@ namespace Admingenerated\{{ namespace_prefix }}{{ bundle_name }}\{{ builder.gene
 use {{ builder.generator.baseController }} as BaseController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 

--- a/Resources/templates/CommonAdmin/NestedListAction/index.php.twig
+++ b/Resources/templates/CommonAdmin/NestedListAction/index.php.twig
@@ -6,7 +6,7 @@ use {{ builder.namespacePrefixWithSubfolder }}\{{ bundle_name }}\Form\Type\{{ bu
 
     public function indexAction(Request $request)
     {
-        $this->request = $request
+        $this->request = $request;
         {{ block('security_action') }}
 
         return $this->render('{{ builder.namespacePrefixForTemplate }}{{ bundle_name }}:{{ builder.BaseGeneratorName }}List:index.html.twig', $this->getAdditionalRenderParameters() + array(

--- a/Resources/templates/CommonAdmin/NestedListAction/index.php.twig
+++ b/Resources/templates/CommonAdmin/NestedListAction/index.php.twig
@@ -4,8 +4,9 @@ use {{ builder.namespacePrefixWithSubfolder }}\{{ bundle_name }}\Form\Type\{{ bu
 {% endblock %}
 {% block index %}
 
-    public function indexAction()
+    public function indexAction(Request $request)
     {
+        $this->request = $request
         {{ block('security_action') }}
 
         return $this->render('{{ builder.namespacePrefixForTemplate }}{{ bundle_name }}:{{ builder.BaseGeneratorName }}List:index.html.twig', $this->getAdditionalRenderParameters() + array(

--- a/Resources/templates/CommonAdmin/NewAction/NewBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/NewAction/NewBuilderAction.php.twig
@@ -116,7 +116,7 @@ class NewController extends BaseController
     protected function getNewType()
     {
         $type = new NewType();
-        $type->setSecurityContext($this->get('security.context'));
+        $type->setAuthorizationChecker($this->get('security.authorization_checker'));
 
         return $type;
     }

--- a/Resources/templates/CommonAdmin/NewAction/NewBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/NewAction/NewBuilderAction.php.twig
@@ -7,6 +7,7 @@ namespace Admingenerated\{{ namespace_prefix }}{{ bundle_name }}\{{ builder.gene
 
 use {{ builder.generator.baseController }} as BaseController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 {{- block('index_use') -}}
 

--- a/Resources/templates/CommonAdmin/NewAction/create.php.twig
+++ b/Resources/templates/CommonAdmin/NewAction/create.php.twig
@@ -3,15 +3,16 @@
 {% endblock %}
 {% block create %}
 
-    public function createAction()
+    public function createAction(Request $request)
     {
+        $this->request = $request;
         {{ block('security_action') }}
 
         ${{ builder.ModelClass }} = $this->getNewObject();
 
         $this->preBindRequest(${{ builder.ModelClass }});
         $form = $this->getNewForm(${{ builder.ModelClass }});
-        $form->handleRequest($this->getRequest());
+        $form->handleRequest($this->request);
         $this->postBindRequest($form, ${{ builder.ModelClass }});
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -25,11 +26,11 @@
                 {% set defaultActionAfterSave = builder.generator.bundleConfig.default_action_after_save %}
                 $actionAfterSave = "{{ actionAfterSave|default(defaultActionAfterSave) }}";
                 $pk = ${{ builder.ModelClass }}->get{{ builder.getFieldGuesser().getModelPrimaryKeyName(model)|classify }}();
-                if ($this->getRequest()->request->has('save-and-add') || ('new' == $actionAfterSave)) {
+                if ($this->request->request->has('save-and-add') || ('new' == $actionAfterSave)) {
                     return new RedirectResponse($this->getNewUrl());
-                } elseif ($this->getRequest()->request->has('save-and-list') || ('list' == $actionAfterSave)) {
+                } elseif ($this->request->request->has('save-and-list') || ('list' == $actionAfterSave)) {
                     return new RedirectResponse($this->getListUrl());
-                } elseif ($this->getRequest()->request->has('save-and-show') || ('show' == $actionAfterSave)) {
+                } elseif ($this->request->request->has('save-and-show') || ('show' == $actionAfterSave)) {
                     return new RedirectResponse($this->getShowUrl($pk));
                 } else {
                     if (('edit' != $actionAfterSave) &&

--- a/Resources/templates/CommonAdmin/NewAction/create.php.twig
+++ b/Resources/templates/CommonAdmin/NewAction/create.php.twig
@@ -11,7 +11,7 @@
 
         $this->preBindRequest(${{ builder.ModelClass }});
         $form = $this->getNewForm(${{ builder.ModelClass }});
-        $form->handleRequest($this->get('request'));
+        $form->handleRequest($this->getRequest());
         $this->postBindRequest($form, ${{ builder.ModelClass }});
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -25,11 +25,11 @@
                 {% set defaultActionAfterSave = builder.generator.bundleConfig.default_action_after_save %}
                 $actionAfterSave = "{{ actionAfterSave|default(defaultActionAfterSave) }}";
                 $pk = ${{ builder.ModelClass }}->get{{ builder.getFieldGuesser().getModelPrimaryKeyName(model)|classify }}();
-                if ($this->get('request')->request->has('save-and-add') || ('new' == $actionAfterSave)) {
+                if ($this->getRequest()->request->has('save-and-add') || ('new' == $actionAfterSave)) {
                     return new RedirectResponse($this->getNewUrl());
-                } else if ($this->get('request')->request->has('save-and-list') || ('list' == $actionAfterSave)) {
+                } elseif ($this->getRequest()->request->has('save-and-list') || ('list' == $actionAfterSave)) {
                     return new RedirectResponse($this->getListUrl());
-                } else if ($this->get('request')->request->has('save-and-show') || ('show' == $actionAfterSave)) {
+                } elseif ($this->getRequest()->request->has('save-and-show') || ('show' == $actionAfterSave)) {
                     return new RedirectResponse($this->getShowUrl($pk));
                 } else {
                     if (('edit' != $actionAfterSave) &&

--- a/Resources/templates/CommonAdmin/NewAction/index.php.twig
+++ b/Resources/templates/CommonAdmin/NewAction/index.php.twig
@@ -5,8 +5,9 @@ use {{ builder.namespacePrefixWithSubfolder }}\{{ bundle_name }}\Form\Type\{{ bu
 {% endblock %}
 {% block index %}
 
-    public function indexAction()
+    public function indexAction(Request $request)
     {
+        $this->request = $request;
         {{ block('security_action') }}
 
         ${{ builder.ModelClass }} = $this->getNewObject();

--- a/Resources/templates/CommonAdmin/ShowAction/ShowBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ShowAction/ShowBuilderAction.php.twig
@@ -6,6 +6,7 @@ namespace Admingenerated\{{ namespace_prefix }}{{ bundle_name }}\{{ builder.gene
 
 use {{ builder.generator.baseController }} as BaseController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 {{- block('index_use') -}}
 

--- a/Resources/templates/CommonAdmin/ShowAction/index.php.twig
+++ b/Resources/templates/CommonAdmin/ShowAction/index.php.twig
@@ -5,8 +5,9 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 {% endblock %}
 {% block index %}
 
-    public function indexAction($pk)
+    public function indexAction(Request $request, $pk)
     {
+        $this->request = $request;
         ${{ builder.ModelClass }} = $this->getObject($pk);
 
         if (!${{ builder.ModelClass }}) {

--- a/Resources/templates/CommonAdmin/csrf_protection.php.twig
+++ b/Resources/templates/CommonAdmin/csrf_protection.php.twig
@@ -12,7 +12,7 @@ use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
     protected function isGeneratedCsrfTokenValid($intention)
     {
         $token = $this->getRequest()->request->get('_csrf_token');
-        if (!$this->get('form.csrf_provider')->isCsrfTokenValid($intention, $token)) {
+        if (!$this->isCsrfTokenValid($intention, $token)) {
             throw new InvalidCsrfTokenException();
         }
     }

--- a/Resources/templates/CommonAdmin/csrf_protection.php.twig
+++ b/Resources/templates/CommonAdmin/csrf_protection.php.twig
@@ -11,8 +11,7 @@ use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
      */
     protected function isGeneratedCsrfTokenValid($intention)
     {
-        $token = $this->getRequest()->request->get('_csrf_token');
-        if (!$this->isCsrfTokenValid($intention, $token)) {
+        if (!$this->isCsrfTokenValid($intention, $this->request->request->get('_csrf_token'))) {
             throw new InvalidCsrfTokenException();
         }
     }
@@ -21,12 +20,10 @@ use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 
 {% block csrf_action_check_token %}
 // Check CSRF token for action
-$intention = $this->getRequest()->getRequestUri();
-$this->isGeneratedCsrfTokenValid($intention);
+$this->isGeneratedCsrfTokenValid($this->request->getRequestUri());
 {% endblock %}
 
 {% block csrf_action_check_batch_token %}
 // Check CSRF token for batch action
-$intention = '{{ builder.baseActionsRoute }}_batch';
-$this->isGeneratedCsrfTokenValid($intention);
+$this->isGeneratedCsrfTokenValid('{{ builder.baseActionsRoute }}_batch');
 {% endblock %}

--- a/Resources/templates/CommonAdmin/security_action.php.twig
+++ b/Resources/templates/CommonAdmin/security_action.php.twig
@@ -28,7 +28,7 @@ use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
     protected function evaluate($expression, \{{ model }} ${{ builder.ModelClass }} = null)
     {
         return $this
-            ->get('security.context')
+            ->get('security.authorization_checker')
             ->isGranted(array(new Expression($expression)), ${{ builder.ModelClass }});
     }
 {% endblock %}

--- a/Resources/templates/EmptyBuilderAction.php.twig
+++ b/Resources/templates/EmptyBuilderAction.php.twig
@@ -4,6 +4,7 @@ namespace {{ namespace }};
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Admingenerator\GeneratorBundle\Exception\CantGenerateException;
+use Symfony\Component\HttpFoundation\Request;
 
 
 /**
@@ -11,12 +12,12 @@ use Admingenerator\GeneratorBundle\Exception\CantGenerateException;
  */
 class {{ controllerName }} extends Controller
 {
-    public function indexAction({% if require_pk %}$pk{% endif %})
+    public function indexAction(Request $request, {% if require_pk %}$pk{% endif %})
     {
-        if ($this->getRequest()->get('stop_loop')) {
+        if ($request->get('stop_loop')) {
             throw new CantGenerateException('Opps an error occurred in your configuration. If you\'re in prod try cache:warmup');
         }
 
-        return $this->redirect($this->getRequest()->getRequestUri()."?stop_loop=true");
+        return $this->redirect($request->getRequestUri()."?stop_loop=true");
     }
 }

--- a/Resources/templates/EmptyBuilderAction.php.twig
+++ b/Resources/templates/EmptyBuilderAction.php.twig
@@ -5,6 +5,7 @@ namespace {{ namespace }};
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Admingenerator\GeneratorBundle\Exception\CantGenerateException;
 
+
 /**
  * AdmingeneratorEmptyBuilderClass
  */
@@ -12,10 +13,10 @@ class {{ controllerName }} extends Controller
 {
     public function indexAction({% if require_pk %}$pk{% endif %})
     {
-        if ($this->get('request')->get('stop_loop')) {
+        if ($this->getRequest()->get('stop_loop')) {
             throw new CantGenerateException('Opps an error occurred in your configuration. If you\'re in prod try cache:warmup');
         }
 
-        return $this->redirect($this->get('request')->getRequestUri()."?stop_loop=true");
+        return $this->redirect($this->getRequest()->getRequestUri()."?stop_loop=true");
     }
 }

--- a/Routing/NestedRoutingLoader.php
+++ b/Routing/NestedRoutingLoader.php
@@ -7,9 +7,10 @@ class NestedRoutingLoader extends RoutingLoader
     public function load($resource, $type = null)
     {
         $this->actions['nested_move'] = array(
-            'pattern'      => '/nested-move/{dragged}/{action}/{dropped}',
+            'path'         => '/nested-move/{dragged}/{action}/{dropped}',
             'defaults'     => array(),
             'requirements' => array(),
+            'methods'      => array('GET'),
             'controller'   => 'list',
         );
 

--- a/Routing/RoutingLoader.php
+++ b/Routing/RoutingLoader.php
@@ -95,7 +95,7 @@ class RoutingLoader extends FileLoader
         $collection = new RouteCollection();
 
         $resource = str_replace('\\', '/', $resource);
-        $this->yaml = Yaml::parse($this->getGeneratorFilePath($resource));
+        $this->yaml = Yaml::parse(file_get_contents($this->getGeneratorFilePath($resource)));
 
         $namespace = $this->getNamespaceFromResource($resource);
         $fullBundleName = $this->getFullBundleNameFromResource($resource);

--- a/Routing/RoutingLoader.php
+++ b/Routing/RoutingLoader.php
@@ -11,76 +11,80 @@ use Symfony\Component\Yaml\Yaml;
 
 class RoutingLoader extends FileLoader
 {
-    // Assoc beetween a controller and is route path
+    // Assoc beetween a controller and its route path
     //@todo make an object for this
     protected $actions = array(
         'list' => array(
                     'pattern'      => '/',
                     'defaults'     => array(),
                     'requirements' => array(),
+                    'methods'      => array('GET'),
                 ),
         'excel'=> array(
                     'pattern'      => '/excel',
                     'defaults'     => array(),
                     'requirements' => array(),
+                    'methods'      => array('GET'),
                     'controller'   => 'excel',
                 ),
         'edit' => array(
                     'pattern'      => '/{pk}/edit',
                     'defaults'     => array(),
                     'requirements' => array(),
+                    'methods'      => array('GET'),
                 ),
         'update' => array(
                     'pattern'      => '/{pk}/update',
                     'defaults'     => array(),
-                    'requirements' => array(
-                        '_method' => 'POST'
-                    ),
+                    'requirements' => array(),
+                    'methods'      => array('POST'),
                     'controller'   => 'edit',
                 ),
         'show' => array(
                     'pattern'      => '/{pk}/show',
                     'defaults'     => array(),
                     'requirements' => array(),
+                    'methods'      => array('GET'),
                 ),
         'object' => array(
                     'pattern'      => '/{pk}/{action}',
                     'defaults'     => array(),
                     'requirements' => array(),
+                    'methods'      => array('GET', 'POST'),
                     'controller'   => 'actions',
                 ),
         'batch' => array(
                     'pattern'      => '/batch',
                     'defaults'     => array(),
-                    'requirements' => array(
-                        '_method' => 'POST'
-                    ),
+                    'requirements' => array(),
+                    'methods'      => array('POST'),
                     'controller'   => 'actions',
                 ),
         'new' => array(
                     'pattern'      => '/new',
                     'defaults'     => array(),
                     'requirements' => array(),
-                    'methods'      => array(),
+                    'methods'      => array('GET'),
                 ),
         'create' => array(
                     'pattern'      => '/create',
                     'defaults'     => array(),
-                    'requirements' => array(
-                        '_method' => 'POST'
-                    ),
+                    'requirements' => array(),
+                    'methods'      => array('POST'),
                     'controller'   => 'new',
                 ),
         'filters' => array(
                     'pattern'      => '/filter',
                     'defaults'     => array(),
                     'requirements' => array(),
+                    'methods'      => array('POST', 'GET'),
                     'controller'   => 'list',
                 ),
         'scopes' => array(
                     'pattern'      => '/scope/{group}/{scope}',
                     'defaults'     => array(),
                     'requirements' => array(),
+                    'methods'      => array('POST', 'GET'),
                     'controller'   => 'list',
                 ),
     );
@@ -139,6 +143,7 @@ class RoutingLoader extends FileLoader
                 }
 
                 $route = new Route($datas['pattern'], $datas['defaults'], $datas['requirements']);
+                $route->setMethods($datas['methods']);
                 $route_name = ltrim($route_name, '_'); // fix routes in AppBundle without vendor
                 $collection->add($route_name, $route);
                 $collection->addResource(new FileResource($controllerName));
@@ -175,11 +180,7 @@ class RoutingLoader extends FileLoader
         $file = $finder->current();
 
         if ($file) {
-            if (PHP_VERSION_ID >= 50306) {
-                return $file->getBasename('.' . $file->getExtension());
-            }
-
-            return $file->getBasename('.' . pathinfo($file->getFilename(), PATHINFO_EXTENSION));
+            return $file->getBasename('.' . $file->getExtension());
         }
 
         return null;

--- a/Routing/RoutingLoader.php
+++ b/Routing/RoutingLoader.php
@@ -15,78 +15,78 @@ class RoutingLoader extends FileLoader
     //@todo make an object for this
     protected $actions = array(
         'list' => array(
-                    'pattern'      => '/',
-                    'defaults'     => array(),
-                    'requirements' => array(),
-                    'methods'      => array('GET'),
-                ),
+            'path'         => '/',
+            'defaults'     => array(),
+            'requirements' => array(),
+            'methods'      => array('GET'),
+        ),
         'excel'=> array(
-                    'pattern'      => '/excel',
-                    'defaults'     => array(),
-                    'requirements' => array(),
-                    'methods'      => array('GET'),
-                    'controller'   => 'excel',
-                ),
+            'path'         => '/excel',
+            'defaults'     => array(),
+            'requirements' => array(),
+            'methods'      => array('GET'),
+            'controller'   => 'excel',
+        ),
         'edit' => array(
-                    'pattern'      => '/{pk}/edit',
-                    'defaults'     => array(),
-                    'requirements' => array(),
-                    'methods'      => array('GET'),
-                ),
+            'path'         => '/{pk}/edit',
+            'defaults'     => array(),
+            'requirements' => array(),
+            'methods'      => array('GET'),
+        ),
         'update' => array(
-                    'pattern'      => '/{pk}/update',
-                    'defaults'     => array(),
-                    'requirements' => array(),
-                    'methods'      => array('POST'),
-                    'controller'   => 'edit',
-                ),
+            'path'         => '/{pk}/update',
+            'defaults'     => array(),
+            'requirements' => array(),
+            'methods'      => array('POST'),
+            'controller'   => 'edit',
+        ),
         'show' => array(
-                    'pattern'      => '/{pk}/show',
-                    'defaults'     => array(),
-                    'requirements' => array(),
-                    'methods'      => array('GET'),
-                ),
+            'path'         => '/{pk}/show',
+            'defaults'     => array(),
+            'requirements' => array(),
+            'methods'      => array('GET'),
+        ),
         'object' => array(
-                    'pattern'      => '/{pk}/{action}',
-                    'defaults'     => array(),
-                    'requirements' => array(),
-                    'methods'      => array('GET', 'POST'),
-                    'controller'   => 'actions',
-                ),
+            'path'         => '/{pk}/{action}',
+            'defaults'     => array(),
+            'requirements' => array(),
+            'methods'      => array('GET', 'POST'),
+            'controller'   => 'actions',
+        ),
         'batch' => array(
-                    'pattern'      => '/batch',
-                    'defaults'     => array(),
-                    'requirements' => array(),
-                    'methods'      => array('POST'),
-                    'controller'   => 'actions',
-                ),
+            'path'         => '/batch',
+            'defaults'     => array(),
+            'requirements' => array(),
+            'methods'      => array('POST'),
+            'controller'   => 'actions',
+        ),
         'new' => array(
-                    'pattern'      => '/new',
-                    'defaults'     => array(),
-                    'requirements' => array(),
-                    'methods'      => array('GET'),
-                ),
+            'path'         => '/new',
+            'defaults'     => array(),
+            'requirements' => array(),
+            'methods'      => array('GET'),
+        ),
         'create' => array(
-                    'pattern'      => '/create',
-                    'defaults'     => array(),
-                    'requirements' => array(),
-                    'methods'      => array('POST'),
-                    'controller'   => 'new',
-                ),
+            'path'         => '/create',
+            'defaults'     => array(),
+            'requirements' => array(),
+            'methods'      => array('POST'),
+            'controller'   => 'new',
+        ),
         'filters' => array(
-                    'pattern'      => '/filter',
-                    'defaults'     => array(),
-                    'requirements' => array(),
-                    'methods'      => array('POST', 'GET'),
-                    'controller'   => 'list',
-                ),
+            'path'         => '/filter',
+            'defaults'     => array(),
+            'requirements' => array(),
+            'methods'      => array('POST', 'GET'),
+            'controller'   => 'list',
+        ),
         'scopes' => array(
-                    'pattern'      => '/scope/{group}/{scope}',
-                    'defaults'     => array(),
-                    'requirements' => array(),
-                    'methods'      => array('POST', 'GET'),
-                    'controller'   => 'list',
-                ),
+            'path'         => '/scope/{group}/{scope}',
+            'defaults'     => array(),
+            'requirements' => array(),
+            'methods'      => array('POST', 'GET'),
+            'controller'   => 'list',
+        ),
     );
 
     /**
@@ -102,7 +102,6 @@ class RoutingLoader extends FileLoader
         $this->yaml = Yaml::parse(file_get_contents($this->getGeneratorFilePath($resource)));
 
         $namespace = $this->getNamespaceFromResource($resource);
-        $fullBundleName = $this->getFullBundleNameFromResource($resource);
         $bundle_name = $this->getBundleNameFromResource($resource);
 
         foreach ($this->actions as $controller => $datas) {
@@ -129,25 +128,30 @@ class RoutingLoader extends FileLoader
             }
 
             $controllerName = $resource.ucfirst($controller).'Controller.php';
-            if (is_file($controllerName)) {
-                if ($controller_folder) {
-                    $datas['defaults']['_controller'] = $namespace . '\\'
-                            . $bundle_name . '\\Controller\\'
-                            . $controller_folder . '\\'
-                            . ucfirst($controller) . 'Controller::'
-                            . $action . 'Action';
-                } else {
-                    $datas['defaults']['_controller'] = $loweredNamespace
-                            . $bundle_name . ':'
-                            . ucfirst($controller) . ':' . $action;
-                }
-
-                $route = new Route($datas['pattern'], $datas['defaults'], $datas['requirements']);
-                $route->setMethods($datas['methods']);
-                $route_name = ltrim($route_name, '_'); // fix routes in AppBundle without vendor
-                $collection->add($route_name, $route);
-                $collection->addResource(new FileResource($controllerName));
+            if (!is_file($controllerName)) {
+                // TODO: what does it mean if controller is not a file??
+                continue;
             }
+
+            if ($controller_folder) {
+                $datas['defaults']['_controller'] = $namespace . '\\'
+                        . $bundle_name . '\\Controller\\'
+                        . $controller_folder . '\\'
+                        . ucfirst($controller) . 'Controller::'
+                        . $action . 'Action';
+            } else {
+                $datas['defaults']['_controller'] = $loweredNamespace
+                        . $bundle_name . ':'
+                        . ucfirst($controller) . ':' . $action;
+            }
+
+            $route = new Route($datas['path'], $datas['defaults'], $datas['requirements']);
+            $route->setMethods($datas['methods']);
+
+            $route_name = ltrim($route_name, '_'); // fix routes in AppBundle without vendor
+
+            $collection->add($route_name, $route);
+            $collection->addResource(new FileResource($controllerName));
         }
 
         return $collection;
@@ -166,24 +170,6 @@ class RoutingLoader extends FileLoader
         preg_match('#.+/.+Bundle/Controller?/(.*?)/?$#', $resource, $matches);
 
         return $matches[1];
-    }
-
-    protected function getFullBundleNameFromResource($resource)
-    {
-        // Find the *Bundle.php
-        $finder = Finder::create()
-            ->name('*Bundle.php')
-            ->depth(0)
-            ->in(realpath($resource.'/../../')) // ressource is controller folder
-            ->getIterator();
-        $finder->rewind();
-        $file = $finder->current();
-
-        if ($file) {
-            return $file->getBasename('.' . $file->getExtension());
-        }
-
-        return null;
     }
 
     /**
@@ -231,7 +217,7 @@ class RoutingLoader extends FileLoader
     /**
      * @param string $yaml_path string with point for levels
      */
-    public function getFromYaml($yaml_path, $default = null)
+    protected function getFromYaml($yaml_path, $default = null)
     {
         $search_in = $this->yaml;
         $yaml_path = explode('.', $yaml_path);

--- a/Validator/BaseValidator.php
+++ b/Validator/BaseValidator.php
@@ -12,7 +12,7 @@ class BaseValidator
      */
     protected function getFromYaml(Generator $generator, $yaml_path, $default = null)
     {
-        $search_in = Yaml::parse($generator->getGeneratorYml());
+        $search_in = Yaml::parse(file_get_contents($generator->getGeneratorYml()));
 
         $yaml_path = explode('.',$yaml_path);
         foreach ($yaml_path as $key) {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": "~2.6",
+        "symfony/symfony": "~2.7",
         "doctrine/common": "~2.2",
         "sensio/generator-bundle": "~2.4",
         "symfony2admingenerator/twig-generator": "~1.1",


### PR DESCRIPTION
## Fix 

Fix issue #72.

## Changes

 - Bumped Symfony version
 - `security.context` => `security.authorization_checker`
 - ~~`request` => `getRequest()`~~
 - `request` => method injection + protected property
 - `bind()` => `handleRequest()`
 - `form.csrf_provider` => `isCsrfTokenValid()`
 - Provide file content to `Yaml::parse` instead of file path
 - Route method is not anymore based on `requirements` option
 - `setDefaultOptions` => `configureOptions` 
 - update `setAllowedTypes` arguments call

If you think about other deprecated call, just let me know or make PR on that PR :)

## BC Break: 
 - Symfony version is fixed to 2.7 min
 - All actions (index, create, update, object, batch, filter, scope) now take as a first parameter the `Request` object
 - Generated forms method `setSecurityContext` have been renamed `setAuthorizationChecker` 