### PR TITLE
Fixes major error in Excel template execution order

### DIFF
--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -130,8 +130,8 @@ class ExcelController extends ListController
         
         // Retrieve relations
         while (($pos = strpos($field, '.')) > 0) {
-            $field = substr($field, $pos + 1);
             $data = $accessor->getValue($data, substr($field, 0, $pos));
+            $field = substr($field, $pos + 1);
         }
         
         $data = $accessor->getValue($data, $field);


### PR DESCRIPTION
With 42cc2bb, an error was introduced with the property accessor when using relations (and thus the point access). This fixes it. 