### PR TITLE
Fix sensio/generator-bundle version dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "symfony/symfony": "~2.6",
         "doctrine/common": "~2.2",
-        "sensio/generator-bundle": "~2.4",
+        "sensio/generator-bundle": "~2.5",
         "symfony2admingenerator/twig-generator": "~1.1",
         "jms/security-extra-bundle": ">= 1.5.0",
         "knplabs/knp-menu-bundle": ">1.0,<2.1",


### PR DESCRIPTION
We should no longer have this based at version 2.4 of `sensio/generator-bundle` so it's better to update the requirement statement.

With version 2.4 of `sensio/generator-bundle` we get:
```
[Symfony\Component\Debug\Exception\ContextErrorException]
Runtime Notice: Declaration of Admingenerator\GeneratorBundle\Command\GenerateAdminAdminCommand::updateRouting() should be compatible with Sensio\Bundle\GeneratorBundle\Command\GenerateBundleComm
and::updateRouting(Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper $dialog, Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $outp
ut, $bundle, $format)
```

Due to signature of method `updateRouting` at `GenerateAdminAdminCommand`.