### PR TITLE
Fixes Reset button being kept disabled when using modal filters

### DIFF
--- a/Resources/templates/CommonAdmin/ListTemplate/ResultsBuilderTemplate.php.twig
+++ b/Resources/templates/CommonAdmin/ListTemplate/ResultsBuilderTemplate.php.twig
@@ -24,7 +24,7 @@
                 {{- block('list_nbresults') -}}
 {% if builder.filtersMode == 'modal' %}
     {{ echo_set('class', '') }}
-    {{ echo_if("app.session.get('\\\\" ~ bundle_name ~ '\\\\' ~ builder.ModelClass ~ "List\\\\Filters',{}) is empty") }}
+    {{ echo_if("app.session.get('" ~ builder.getNamespacePrefixForTemplate ~ '\\\\' ~ bundle_name ~ '\\\\' ~ builder.baseGeneratorName ~ "List\\\\Filters',{}) is empty") }}
     {{ echo_set('class', 'disabled') }}
     {{ echo_endif() }}
                 <div class="box-tools pull-right">          


### PR DESCRIPTION
When using the modal filters functionality, the reset button is disabled even when filters are used. This was due to the namespace being assimilated wrongly, and this PR fixes that.