### PR TITLE
Fix to allow rendering a controller in the show template if no partial added

### DIFF
--- a/Resources/templates/CommonAdmin/ShowTemplate/sidebar.php.twig
+++ b/Resources/templates/CommonAdmin/ShowTemplate/sidebar.php.twig
@@ -11,7 +11,7 @@
                             <h3 class="box-title">{{ echo_trans(name,{}, i18n_catalog|default("Admin") ) }}</h3>
                         </div>
                         <div class="box-body">
-                            {% if widget.partial %}
+                            {% if widget.partial is defined %}
                                 {{ echo_include(widget.partial) }}
                             {% elseif widget.render %}
                                 {{ echo_render(widget.render is iterable ?  widget.render.controller : widget.render, widget.render is iterable ? widget.render.params : {}) }}


### PR DESCRIPTION
When trying to render a controller in show action, an error was thrown if not added any partials