### PR TITLE
Fixes list not fully occupying screen due to modal filters toolbox

### DIFF
--- a/Resources/templates/CommonAdmin/ListTemplate/ResultsBuilderTemplate.php.twig
+++ b/Resources/templates/CommonAdmin/ListTemplate/ResultsBuilderTemplate.php.twig
@@ -20,7 +20,7 @@
     <div class="col-md-12 list-results-container no-filters">
     {% endif %}
         <div class="box box-primary">
-            <div class="box-header list-header list-nb-results">
+            <div class="box-header list-header list-nb-results clearfix">
                 {{- block('list_nbresults') -}}
 {% if builder.filtersMode == 'modal' %}
     {{ echo_set('class', '') }}


### PR DESCRIPTION
When using modal filters, the toolbox occupies a small piece on the right part of the screen, forcing the list table to be smaller.
This PR fixes that.

Previous: https://www.dropbox.com/s/5pd30nmu9uisrba/Schermafdruk%202015-08-14%2012.23.36.png?dl=0
New: https://www.dropbox.com/s/e58g7csv59zgkix/Schermafdruk%202015-08-14%2012.26.55.png?dl=0