### PR TITLE
[PATCH] Fix filters update via GET request

### DIFF
--- a/Resources/templates/Doctrine/ListBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/ListBuilderAction.php.twig
@@ -12,7 +12,7 @@
             {% set filterModel = builder.getFieldGuesser().getModelType(model, column.filterOn) %}
         if (isset($filters['{{ filter }}'])) {
                 $filters['{{ filter }}'] = array (
-                    '{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel) }}' => $filters['{{ filter }}']->get{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel)|capitalize }}(),
+                    '{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel) }}' => is_object($filters['{{ filter }}']) ? $filters['{{ filter }}']->get{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel)|capitalize }}() : $filters['{{ filter }}'],
                     'entityName' => '{{ filterModel }}'
                 );
         }


### PR DESCRIPTION
When you set filters via GET request  in query string you can only set primary id of related object, NOT the object itself. I'm adding conditional check for such case.