### PR TITLE
[PATCH] Add omitted parameter to echo_if_granted calls

### DIFF
--- a/Resources/templates/CommonAdmin/generic_actions.php.twig
+++ b/Resources/templates/CommonAdmin/generic_actions.php.twig
@@ -2,12 +2,12 @@
     {{ echo_block("generic_actions") }}
             {% if builder.actions|default is not empty %}
                 {{ echo_block('pre_generic_actions') }}{{ echo_endblock() }}
-                {{ echo_if_granted(builder.actions|mapBy('credentials')|flatten|join(' or ')|default('denyAll')) }}
+                {{ echo_if_granted(builder.actions|mapBy('credentials')|flatten|join(' or ')|default('denyAll'), builder.ModelClass) }}
 
                 {% for action in builder.Actions %}
                     {{ echo_block("generic_action_" ~ action.twigName) }}
                     {% if action.credentials %}
-                        {{ echo_if_granted(action.credentials) }}
+                        {{ echo_if_granted(action.credentials, builder.ModelClass) }}
                     {% endif %}
 
                     {{ block('generic_action_block') }}


### PR DESCRIPTION
Without this patch no object instance passed to custom security function as described in https://github.com/symfony2admingenerator/AdmingeneratorGeneratorBundle/blob/master/Resources/doc/security/credentials.md
```yaml
# ...
           actions:
                list: ~
                edit: 
                    credentials:        'isEditableByUser(object)'   
# ...
```