### PR TITLE
new feature: filtering through url

### DIFF
--- a/Resources/templates/CommonAdmin/ListAction/scopes.php.twig
+++ b/Resources/templates/CommonAdmin/ListAction/scopes.php.twig
@@ -106,7 +106,7 @@
                 {% if params["filters"] is defined -%}
                     {%- for filter, filterParams in params["filters"] -%}
                         {%- if not filter|is_numeric -%}
-                            $filters['{{ filter }}'] = '{{ filterParams }}';
+                            $filters['{{ filter }}'] = {%- if filterParams is not iterable -%}'{{ filterParams }}'{%- else -%}array({% for param in filterParams %}'{{ param }}'{% if not loop.last %},{% endif %}{% endfor %}){%- endif -%};
                         {%- endif -%}
                     {%- endfor -%}
                 {%- endif %}

--- a/Resources/templates/Doctrine/ListBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/ListBuilderAction.php.twig
@@ -10,9 +10,18 @@
         {%- for filter,column in builder.filterColumns -%}
             {%- if 'entity' == builder.getFieldGuesser().getDbType(model, column.filterOn) or 'collection' == builder.getFieldGuesser().getDbType(model, column.filterOn) -%}
             {% set filterModel = builder.getFieldGuesser().getModelType(model, column.filterOn) %}
-        if (isset($filters['{{ filter }}'])) {
+        if (isset($filters['{{ filter }}']) && $filters['{{ filter }}'] instanceof \{{ filterModel }} ) {
                 $filters['{{ filter }}'] = array (
                     '{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel) }}' => is_object($filters['{{ filter }}']) ? $filters['{{ filter }}']->get{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel)|capitalize }}() : $filters['{{ filter }}'],
+                    'entityName' => '{{ filterModel }}'
+                );
+        }
+            {%- endif %}
+            {%- if 'entity' == builder.getFieldGuesser().getDbType(model, column.filterOn) or 'collection' == builder.getFieldGuesser().getDbType(model, column.filterOn) -%}
+            {% set filterModel = builder.getFieldGuesser().getModelType(model, column.filterOn) %}
+        if (isset($filters['{{ filter }}_{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel)|lower }}']) && is_string($filters['{{ filter }}_{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel)|lower }}'])) {
+                $filters['{{ filter }}'] = array (
+                    '{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel) }}' => $filters['{{ filter }}_{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel)|lower }}'],
                     'entityName' => '{{ filterModel }}'
                 );
         }

--- a/Resources/templates/Doctrine/ListBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/ListBuilderAction.php.twig
@@ -19,11 +19,13 @@
             {%- endif %}
             {%- if 'entity' == builder.getFieldGuesser().getDbType(model, column.filterOn) or 'collection' == builder.getFieldGuesser().getDbType(model, column.filterOn) -%}
             {% set filterModel = builder.getFieldGuesser().getModelType(model, column.filterOn) %}
-        if (isset($filters['{{ filter }}_{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel)|lower }}']) && is_string($filters['{{ filter }}_{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel)|lower }}'])) {
+            {% set filterByIdName = filter ~ '_' ~ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel)|lower %}
+        if (isset($filters['{{ filterByIdName }}']) && is_string($filters['{{ filterByIdName }}'])) {
                 $filters['{{ filter }}'] = array (
-                    '{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel) }}' => $filters['{{ filter }}_{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel)|lower }}'],
+                    '{{ builder.getFieldGuesser().getModelPrimaryKeyName(filterModel) }}' => $filters['{{ filterByIdName }}'],
                     'entityName' => '{{ filterModel }}'
                 );
+                unset($filters['{{ filterByIdName }}']);
         }
             {%- endif %}
         {% endfor -%}


### PR DESCRIPTION
hi,

i have added a possibility to use filter field in url.

Example (user is in company):
User-generator:
```yaml
        company:
            filterable: true
            filterType: s2a_select2_entity
            formType: s2a_select2_entity
            label: Company
            sort_on: company.shortName
            addFilterOptions:
                class: 'Bundle:Company'
```

Company row.twig:
```twig
{% block list_td_column_name %}
	<a href="{{ path("Bundle_User_filters", { company_id: Company.id }) }}">{{ Company.name }}</a>
{% endblock list_td_column_name %}
```
or

Company.generator:
```yaml
    object_actions:
        list_users:
            label: List users
            icon:   fa-user
            route:    Bundle_User_filters
            params:
                company_id:       "{{ Company.id }}"
```