### PR TITLE
Remove deprecated calls and classes since Twig 1.12

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -43,7 +43,7 @@
         
         <service id="twig.extension.admingenerator.csrf" class="Admingenerator\GeneratorBundle\Twig\Extension\CsrfTokenExtension" public="false">
             <tag name="twig.extension" />
-            <argument type="service" id="form.csrf_provider" />
+            <argument type="service" id="security.csrf.token_manager" />
         </service>
         
         <service id="twig.extension.admingenerator.localized_money" class="Admingenerator\GeneratorBundle\Twig\Extension\LocalizedMoneyExtension" public="false">

--- a/Resources/templates/CommonAdmin/ActionsAction/ActionsBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ActionsAction/ActionsBuilderAction.php.twig
@@ -65,7 +65,7 @@ class ActionsController extends BaseController
     }
 
     {% for action in builder.ObjectActions %}
-        {% if action.name is sameas('delete') %}
+        {% if action.name is same as('delete') %}
             {{- block('attemptObjectDelete') -}}
             {{- block('executeObjectDelete') -}}
             {{- block('successObjectDelete') -}}
@@ -79,7 +79,7 @@ class ActionsController extends BaseController
     {% endfor %}
 
     {% for action in builder.BatchActions %}
-        {% if action.name is sameas('delete') %}
+        {% if action.name is same as('delete') %}
             {{- block('attemptBatchDelete') -}}
             {{- block('executeBatchDelete') -}}
             {{- block('successBatchDelete') -}}

--- a/Resources/templates/CommonAdmin/EditTemplate/EditBuilderTemplate.php.twig
+++ b/Resources/templates/CommonAdmin/EditTemplate/EditBuilderTemplate.php.twig
@@ -30,9 +30,9 @@
             <form
             {{ echo_for('attrvalue', 'attr', 'attrname') }}
                 {{ echo_twig('" "') }}
-                {{ echo_if('attrvalue is sameas(true)') }}
+                {{ echo_if('attrvalue is same as(true)') }}
                     {{- echo_twig('attrname') }}="{{ echo_twig('attrname') }}"
-                {{ echo_elseif('attrvalue is not sameas(false)') }}
+                {{ echo_elseif('attrvalue is not same as(false)') }}
                     {{ echo_twig('attrname') }}="{{ echo_twig('attrvalue') }}"
                 {{ echo_endif() }}
             {{ echo_endfor() }}

--- a/Resources/templates/CommonAdmin/EditType/type.php.twig
+++ b/Resources/templates/CommonAdmin/EditType/type.php.twig
@@ -10,8 +10,6 @@ use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
 
 class {{ builder.YamlKey|ucfirst }}Type extends BaseType
 {
-    protected $securityContext;
-
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $this->groups = $options['groups'];

--- a/Resources/templates/CommonAdmin/FiltersType/type.php.twig
+++ b/Resources/templates/CommonAdmin/FiltersType/type.php.twig
@@ -10,8 +10,6 @@ use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
 
 class FiltersType extends BaseType
 {
-    protected $securityContext;
-
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $this->groups = $options['groups'];

--- a/Resources/templates/CommonAdmin/ListTemplate/paginator.php.twig
+++ b/Resources/templates/CommonAdmin/ListTemplate/paginator.php.twig
@@ -9,7 +9,7 @@
 
 {% block list_paginator_perpage %}
     {{ echo_block("list_paginator_perpage") }}
-        {{ echo_if( builder.ModelClass ~ "s.haveToPaginate or "~ builder.ModelClass ~ "s.maxPerPage is not sameas(perPageChoices|first)") }}
+        {{ echo_if( builder.ModelClass ~ "s.haveToPaginate or "~ builder.ModelClass ~ "s.maxPerPage is not same as(perPageChoices|first)") }}
             <div class="btn-group dropup pull-right">
                 <div class="btn btn-sm btn-default btn-reset">{{ echo_trans('pagerfanta.view.perpage') }}</div>
                 <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown">

--- a/Resources/templates/CommonAdmin/batch_actions.php.twig
+++ b/Resources/templates/CommonAdmin/batch_actions.php.twig
@@ -29,7 +29,7 @@
 {% endblock %}
 
 {% block batch_action_block %}
-    {% set translationDomain = action.type is sameas('custom') ? i18n_catalog|default("Admin") : 'Admingenerator' %}
+    {% set translationDomain = action.type is same as('custom') ? i18n_catalog|default("Admin") : 'Admingenerator' %}
     <option
         value="{{ action.name }}"
         {%- if action.confirm %} data-confirm="{{ echo_trans(action.confirm, {}, translationDomain, 'html_attr') }}" {% endif -%}

--- a/Resources/templates/CommonAdmin/generic_actions.php.twig
+++ b/Resources/templates/CommonAdmin/generic_actions.php.twig
@@ -27,7 +27,7 @@
 {% block generic_action_block %}
     {% set actionRoute = action.route ? action.route : builder.baseActionsRoute ~ '_' ~ action.name %}
     {% set actionParams = action.params ? echo_twig_assoc(action.params) : "{}" %}
-    {% set translationDomain = action.type is sameas('custom') ? i18n_catalog|default("Admin") : 'Admingenerator' %}
+    {% set translationDomain = action.type is same as('custom') ? i18n_catalog|default("Admin") : 'Admingenerator' %}
 
     {% if action.submit %}
         <button type="submit" name="{{ action.name }}" class="generic-action btn {{ action.class|default('btn-default') }}"

--- a/Resources/templates/CommonAdmin/object_actions.php.twig
+++ b/Resources/templates/CommonAdmin/object_actions.php.twig
@@ -23,14 +23,14 @@
 {% block object_action_block %}
     {% set actionRoute  = action.route ? action.route : builder.getObjectActionsRoute %}
     {% set actionParams = action.params ? echo_twig_assoc(action.params) : "{ 'pk': " ~ builder.ModelClass ~ "." ~ builder.getFieldGuesser().getModelPrimaryKeyName(model) ~ ", action: '" ~ action.name ~ "' }" %}
-    {% set translationDomain = action.type is sameas('custom') ? i18n_catalog|default("Admin") : 'Admingenerator' %}
+    {% set translationDomain = action.type is same as('custom') ? i18n_catalog|default("Admin") : 'Admingenerator' %}
 
     {% spaceless %}
         {{ echo_spaceless() }}
-        <a  class="object-action btn btn-default {% if builder.yamlKey is sameas('list') or builder.yamlKey is sameas('nested_list') %}btn-xs {% endif %}{{ action.class|default('') }}"
+        <a  class="object-action btn btn-default {% if builder.yamlKey is same as('list') or builder.yamlKey is same as('nested_list') %}btn-xs {% endif %}{{ action.class|default('') }}"
             href="{{ echo_path(actionRoute, actionParams) }}"
             title="{{ echo_trans(action.label, {}, translationDomain, 'html_attr') }}"
-                {% if builder.yamlKey is sameas('list') or builder.yamlKey is sameas('nested_list') %}
+                {% if builder.yamlKey is same as('list') or builder.yamlKey is same as('nested_list') %}
                     data-toggle="tooltip"
                 {% endif %}
                 {%- if action.confirm %} data-confirm="{{ echo_trans(action.confirm, {}, translationDomain, 'html_attr') }}" {% endif -%}

--- a/Resources/templates/CommonAdmin/security_action.php.twig
+++ b/Resources/templates/CommonAdmin/security_action.php.twig
@@ -34,7 +34,7 @@ use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
 {% endblock %}
 
 {% block security_action %}
-{% if builder.yamlKey is sameas('actions')  %}
+{% if builder.yamlKey is same as('actions')  %}
     {% if action is defined and action.credentials %}
     $this->checkCredentials('{{ action.credentials }}');
     {% endif %}
@@ -44,7 +44,7 @@ use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
 {% endblock %}
 
 {% block security_action_with_object %}
-{% if builder.yamlKey is sameas('actions') %}
+{% if builder.yamlKey is same as('actions') %}
     {% if action is defined and action.credentials %}
     $this->checkCredentials('{{ action.credentials }}', ${{ builder.ModelClass }});
     {% endif %}

--- a/Twig/Extension/ArrayExtension.php
+++ b/Twig/Extension/ArrayExtension.php
@@ -14,9 +14,9 @@ class ArrayExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'mapBy'     => new \Twig_Filter_Method($this, 'mapBy'),
-            'flatten'   => new \Twig_Filter_Method($this, 'flatten'),
-            'intersect' => new \Twig_Filter_Method($this, 'intersect'),
+            'mapBy'     => new \Twig_SimpleFilter('mapBy', array($this, 'mapBy')),
+            'flatten'   => new \Twig_SimpleFilter('flatten', array($this, 'flatten')),
+            'intersect' => new \Twig_SimpleFilter('intersect', array($this, 'intersect')),
         );
     }
 

--- a/Twig/Extension/ConfigExtension.php
+++ b/Twig/Extension/ConfigExtension.php
@@ -26,7 +26,7 @@ class ConfigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'admingenerator_config' => new \Twig_Function_Method($this, 'getAdmingeneratorConfig'),
+            'admingenerator_config' => new \Twig_SimpleFunction('admingenerator_config', array($this, 'getAdmingeneratorConfig')),
         );
     }
 

--- a/Twig/Extension/CsrfTokenExtension.php
+++ b/Twig/Extension/CsrfTokenExtension.php
@@ -29,7 +29,7 @@ class CsrfTokenExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'csrf_token' => new \Twig_SimpleFilter('csrf_filter', array($this, 'getCsrfToken')),
+            'csrf_token' => new \Twig_SimpleFilter('csrf_token', array($this, 'getCsrfToken')),
         );
     }
 

--- a/Twig/Extension/CsrfTokenExtension.php
+++ b/Twig/Extension/CsrfTokenExtension.php
@@ -3,6 +3,7 @@
 namespace Admingenerator\GeneratorBundle\Twig\Extension;
 
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /**
  * @author Stéphane Escandell
@@ -10,16 +11,16 @@ use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
 class CsrfTokenExtension extends \Twig_Extension
 {
     /**
-     * @var CsrfProviderInterface
+     * @var CsrfTokenManagerInterface
      */
-    protected $csrfProvider;
+    protected $csrfTokenManager;
 
     /**
-     * @param CsrfProviderInterface $csrfProvider
+     * @param CsrfTokenManagerInterface $csrfTokenManager
      */
-    public function __construct(CsrfProviderInterface $csrfProvider)
+    public function __construct(CsrfTokenManagerInterface $csrfTokenManager)
     {
-        $this->csrfProvider = $csrfProvider;
+        $this->csrfTokenManager = $csrfTokenManager;
     }
 
     /**
@@ -28,13 +29,13 @@ class CsrfTokenExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'csrf_token' => new \Twig_Filter_Method($this, 'getCsrfToken'),
+            'csrf_token' => new \Twig_SimpleFilter('csrf_filter', array($this, 'getCsrfToken')),
         );
     }
 
     public function getCsrfToken($intention)
     {
-        return $this->csrfProvider->generateCsrfToken($intention);
+        return $this->csrfTokenManager->getToken($intention);
     }
 
     /**

--- a/Twig/Extension/EchoExtension.php
+++ b/Twig/Extension/EchoExtension.php
@@ -15,10 +15,10 @@ class EchoExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'echo_if_granted'     => new \Twig_Function_Method($this, 'getEchoIfGranted'),
-            'echo_path'           => new \Twig_Function_Method($this, 'getEchoPath'),
-            'echo_trans'          => new \Twig_Function_Method($this, 'getEchoTrans'),
-            'echo_render'         => new \Twig_Function_Method($this, 'getEchoRender')
+            'echo_if_granted'     => new \Twig_SimpleFunction('echo_if_granted', array($this, 'getEchoIfGranted')),
+            'echo_path'           => new \Twig_SimpleFunction('echo_path', array($this, 'getEchoPath')),
+            'echo_trans'          => new \Twig_SimpleFunction('echo_trans', array($this, 'getEchoTrans')),
+            'echo_render'         => new \Twig_SimpleFunction('echo_render', array($this, 'getEchoRender'))
         );
     }
 
@@ -28,7 +28,7 @@ class EchoExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'convert_as_form' => new \Twig_Filter_Method($this, 'convertAsForm'),
+            'convert_as_form' => new \Twig_SimpleFilter('convert_as_form', array($this, 'convertAsForm')),
         );
     }
 

--- a/Twig/Extension/LocalizedMoneyExtension.php
+++ b/Twig/Extension/LocalizedMoneyExtension.php
@@ -12,8 +12,8 @@ class LocalizedMoneyExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'localized_money' => new \Twig_Function_Method($this, 'getLocalizedMoney'),
-            'currency_sign'   => new \Twig_Function_Method($this, 'getCurrencySign'),
+            'localized_money' => new \Twig_SimpleFunction('localized_money', array($this, 'getLocalizedMoney')),
+            'currency_sign'   => new \Twig_SimpleFunction('currency_sign', array($this, 'getCurrencySign')),
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "jms/security-extra-bundle": ">= 1.5.0",
         "knplabs/knp-menu-bundle": ">1.0,<2.1",
         "white-october/pagerfanta-bundle": "~1.0",
-        "twig/twig": ">= 1.9.0",
+        "twig/twig": ">= 1.12.0",
         "twig/extensions": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
The `Twig_Filter_Method` and `Twig_Function_Method` classes have been deprecated in favor of the `Twig_SimpleFilter` and `Twig_SimpleFunction` classes.
This PR fixes that for this repo.
It also fixes some other deprecated errors.