### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "sensio/generator-bundle": "~2.5",
         "symfony2admingenerator/twig-generator": "~1.1",
         "jms/security-extra-bundle": ">= 1.5.0",
-        "knplabs/knp-menu-bundle": ">1.0,<2.1",
+        "knplabs/knp-menu-bundle": ">1.0,<2.2",
         "white-october/pagerfanta-bundle": "~1.0",
         "twig/twig": ">= 1.12.0",
         "twig/extensions": "~1.0"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "symfony/symfony": "~2.7",
         "doctrine/common": "~2.2",
-        "sensio/generator-bundle": "~2.5",
+        "sensio/generator-bundle": "~2.5|~3.0",
         "symfony2admingenerator/twig-generator": "~1.1",
         "jms/security-extra-bundle": ">= 1.5.0",
         "knplabs/knp-menu-bundle": ">1.0,<2.2",


### PR DESCRIPTION
KnpMenuBundle and SensioGeneratorBundle have been updated, but we cannot use the new versions as they're blocked by the composer.json of this bundle.
Please allow the new version.