### PR TITLE
Fix the use of expressions in the credentials handling

### DIFF
--- a/Resources/templates/CommonAdmin/EditType/type.php.twig
+++ b/Resources/templates/CommonAdmin/EditType/type.php.twig
@@ -5,6 +5,9 @@ namespace Admingenerated\{{ namespace_prefix }}{{ bundle_name }}\Form\Base{{ bui
 
 use Admingenerator\GeneratorBundle\Form\BaseType;
 use Admingenerator\GeneratorBundle\Form\BaseOptions;
+{% if(admingenerator_config('use_jms_security')) %}
+use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
+{% endif %}
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -71,7 +74,12 @@ class {{ builder.YamlKey|ucfirst }}Type extends BaseType
     protected function canDisplay{{ column.name|classify|php_name }}(\{{ model }} ${{ builder.ModelClass }} = null)
     {
         {% if column.credentials is not empty %}
-            return $this->checkCredentials('{{ column.credentials }}', ${{ builder.ModelClass }});
+            {% if(admingenerator_config('use_jms_security')) %}
+                $credentials = new Expression('{{ column.credentials }}');
+            {% else %}
+                $credentials = '{{ column.credentials }}';
+            {% endif %}
+            return $this->checkCredentials($credentials, ${{ builder.ModelClass }});
         {% else %}
             return true;
         {% endif %}

--- a/Resources/templates/CommonAdmin/FiltersType/type.php.twig
+++ b/Resources/templates/CommonAdmin/FiltersType/type.php.twig
@@ -5,8 +5,11 @@ namespace Admingenerated\{{ namespace_prefix }}{{ bundle_name }}\Form\Base{{ bui
 
 use Admingenerator\GeneratorBundle\Form\BaseType;
 use Admingenerator\GeneratorBundle\Form\BaseOptions;
-use Symfony\Component\Form\FormBuilderInterface;
+{% if(admingenerator_config('use_jms_security')) %}
 use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
+{% endif %}
+use Symfony\Component\Form\FormBuilderInterface;
+
 
 class FiltersType extends BaseType
 {
@@ -57,7 +60,12 @@ class FiltersType extends BaseType
         protected function canDisplay{{ column.name|classify|php_name }}()
         {
             {% if column.filtersCredentials is not empty %}
-                return $this->checkCredentials('{{ column.filtersCredentials }}', null);
+                {% if(admingenerator_config('use_jms_security')) %}
+                    $credentials = new Expression('{{ column.filtersCredentials }}');
+                {% else %}
+                    $credentials = '{{ column.filtersCredentials }}';
+                {% endif %}
+                return $this->checkCredentials($credentials, null);
             {% else %}
                 return true;
             {% endif %}


### PR DESCRIPTION
When reverting the usage of groups to credentials, a few references to isGranted were missed, while a perfect implementation in the SecurityExtension was available. This PR fixes this discrepancy, so that also the formtypes and all templates use the isOneGranted method.

Without, a mixed behavior is yielded, which sometimes checks using the JMSSecurityExtraBundle structure and sometimes using the built-in isGranted, making it impossible to use the JMSSecurityExtraBundle structure.