### PR TITLE
Fix an error with AdmingenAllowed in form checking

### DIFF
--- a/Resources/templates/CommonAdmin/EditType/type.php.twig
+++ b/Resources/templates/CommonAdmin/EditType/type.php.twig
@@ -73,7 +73,7 @@ class {{ builder.YamlKey|ucfirst }}Type extends BaseType
      */
     protected function canDisplay{{ column.name|classify|php_name }}(\{{ model }} ${{ builder.ModelClass }} = null)
     {
-        {% if column.credentials is not empty %}
+        {% if column.credentials is not empty and column.credentials != 'AdmingenAllowed' %}
             {% if(admingenerator_config('use_jms_security')) %}
                 $credentials = new Expression('{{ column.credentials }}');
             {% else %}

--- a/Resources/templates/CommonAdmin/FiltersType/type.php.twig
+++ b/Resources/templates/CommonAdmin/FiltersType/type.php.twig
@@ -59,7 +59,7 @@ class FiltersType extends BaseType
         */
         protected function canDisplay{{ column.name|classify|php_name }}()
         {
-            {% if column.filtersCredentials is not empty %}
+            {% if column.filtersCredentials is not empty and column.filtersCredentials != 'AdmingenAllowed' %}
                 {% if(admingenerator_config('use_jms_security')) %}
                     $credentials = new Expression('{{ column.filtersCredentials }}');
                 {% else %}


### PR DESCRIPTION
I'm sorry for bothering again, but I've made an error in the credentials checking in forms, leading to the `JMSSecurityBundle` wanting to parse the expression `'AdmingenAllowed'` which fails.
This is properly filtered out in this PR in my opinion.