### PR TITLE
Fix credentials checking in Excel builder when empty

### DIFF
--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -85,7 +85,7 @@ class ExcelController extends \{{ namespace_prefix }}\{{ bundle_name }}\Controll
 
         $colNum = 0;
         {% for column in builder.columns %}
-            {% if column.credentials is not empty %}
+            {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
             {% set credentials = column.credentials %}
             if ($this->validateCredentials('{{ credentials }}')) {
             {% endif %}
@@ -95,7 +95,7 @@ class ExcelController extends \{{ namespace_prefix }}\{{ bundle_name }}\Controll
             $sheet->getColumnDimension($columnLetter)->setAutoSize(true);
 
             $colNum++;
-            {% if column.credentials is not empty %}
+            {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
             }
             {% endif %}
         {% endfor %}
@@ -112,7 +112,7 @@ class ExcelController extends \{{ namespace_prefix }}\{{ bundle_name }}\Controll
         foreach($results as ${{ builder.ModelClass }}) {
             $colNum = 0;
             {% for name,column in builder.columns %}
-                {% if column.credentials is not empty %}
+                {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
                     {% set credentials = column.credentials %}
                 if ($this->validateCredentials('{{ credentials }}', ${{ builder.ModelClass }})) {
                 {% endif %}
@@ -125,7 +125,7 @@ class ExcelController extends \{{ namespace_prefix }}\{{ bundle_name }}\Controll
                 }
 
                 $sheet->setCellValueByColumnAndRow($colNum, $row, $formatedValue);
-                {% if column.credentials is not empty %}
+                {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
                 }
                 {% endif %}
             // Inc is outside of the credentials check to be sync with headers.

--- a/Resources/templates/CommonAdmin/security_action.php.twig
+++ b/Resources/templates/CommonAdmin/security_action.php.twig
@@ -42,7 +42,7 @@
         {% if action is defined and action.credentials and action.credentials is not same as('AdmingenAllowed') %}
             $this->denyAccessUnlessValidateCredentials('{{ action.credentials }}');
         {% endif %}
-    {% elseif credentials %}
+    {% elseif credentials is defined and credentials is not same as('AdmingenAllowed') %}
         $this->denyAccessUnlessValidateCredentials('{{ credentials }}');
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Not all credentials were checked for `AdmingenAllowed`, so it fails when using `JMSSecurityBundle`.
This PR fixes that.