### PR TITLE
Add option --forms-only to generate-admin command

### DIFF
--- a/Builder/Generator.php
+++ b/Builder/Generator.php
@@ -446,6 +446,22 @@ class Generator extends TwigGeneratorGenerator
     }
 
     /**
+     * @return array
+     */
+    public function getBuildersFromYaml()
+    {
+        return $this->getFromYaml('builders', array());
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isFormsOnly()
+    {
+        return $this->getFromYaml('params.forms_only', false);
+    }
+
+    /**
      * @param array     $array      The array to traverse.
      * @param string    $path       Path string with point for levels.
      * @param mixed     $default    Value to default to, path key not found.

--- a/Command/GenerateAdminCommand.php
+++ b/Command/GenerateAdminCommand.php
@@ -232,7 +232,9 @@ EOT
         $runner($this->updateKernel($output, $this->getContainer()->get('kernel'), $bundle));
 
         // routing
-        $runner($this->updateRouting($output, $bundle, $input->getOption('prefix')));
+        if (!$input->hasOption('forms-only')) {
+            $runner($this->updateRouting($output, $bundle, $input->getOption('prefix')));
+        }
 
         $questionHelper->writeGeneratorSummary($output, $errors);
     }

--- a/Command/GenerateAdminCommand.php
+++ b/Command/GenerateAdminCommand.php
@@ -26,9 +26,9 @@ class GenerateAdminCommand extends GeneratorCommand
                 new InputOption('dir', '', InputOption::VALUE_REQUIRED, 'The directory where the bundle is', 'src/'),
                 new InputOption('bundle-name', '', InputOption::VALUE_REQUIRED, 'The bundle name'),
                 new InputOption('generator', '', InputOption::VALUE_REQUIRED, 'The generator service (propel, doctrine, doctrine_odm)', 'doctrine'),
-                new InputOption('model-name', '', InputOption::VALUE_REQUIRED, 'Base model name for admin module, without namespace.', 'YourModel'),
+                new InputOption('model-name', '', InputOption::VALUE_REQUIRED, 'Base model name for admin module, without namespace.'),
                 new InputOption('prefix', '', InputOption::VALUE_REQUIRED, 'The generator prefix ([prefix]-generator.yml)'),
-
+                new InputOption('forms-only', null, InputOption::VALUE_NONE, 'If set, only forms will be auto-generated.')
             ))
             ->setHelp(<<<EOT
 The <info>admin:generate-admin</info> command helps you generates new admin pages for a given model.
@@ -216,7 +216,8 @@ EOT
         $generator->setPrefix($input->getOption('prefix'));
         $generator->generate(
             $bundle,
-            $input->getOption('model-name')
+            $input->getOption('model-name'),
+            $input->hasOption('forms-only')
         );
 
         $output->writeln('Generating the bundle code: <info>OK</info>');
@@ -309,13 +310,13 @@ EOT
         try {
             $ret = $routing->addResource($bundle->getName(), 'admingenerator');
             if (!$ret) {
-                $help = sprintf("        <comment>resource: \"@%s/Controller/%s/\"</comment>\n        <comment>type:     admingenerator</comment>\n", $bundle->getName(), ucfirst($prefix));
-                $help .= "        <comment>prefix:   /</comment>\n";
+                $help = sprintf("\t\t<comment>resource: \"@%s/Controller/%s/\"</comment>\n\t<comment>type:\tadmingenerator</comment>\n", $bundle->getName(), ucfirst($prefix));
+                $help .= "\t\t<comment>prefix:\t/</comment>\n";
 
                 return array(
                     '- Import the bundle\'s routing resource in the app main routing file:',
                     '',
-                    sprintf('    <comment>%s:</comment>', $bundle->getName()),
+                    sprintf('\t<comment>%s:</comment>', $bundle->getName()),
                     $help,
                     '',
                 );

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -93,7 +93,7 @@ class BundleGenerator extends BaseBundleGenerator
      * @param Bundle $bundle
      * @param string $modelName
      */
-    public function generate(Bundle $bundle, $modelName)
+    public function generate(Bundle $bundle, $modelName, $formsOnly)
     {
         $dir = $bundle->getTargetDirectory();
 
@@ -127,33 +127,11 @@ class BundleGenerator extends BaseBundleGenerator
             'model_folder'     => $modelFolder,
             'model_name'       => $modelName,
             'prefix'           => ucfirst($this->prefix),
+            'forms_only'       => $formsOnly
         );
 
         if (!file_exists($dir.'/'.$bundle->getName().'.php')) {
             $this->renderGeneratedFile('Bundle.php.twig', $dir.'/'.$bundle->getName().'.php', $parameters);
-        }
-
-        foreach ($this->actions as $action => $actionProperties) {
-            $parameters['action'] = $action;
-
-            $controllerFile = $dir.'/Controller/'
-                .($this->prefix ? ucfirst($this->prefix).'/' : '').$action.'Controller.php';
-            $this->copyPreviousFile($controllerFile);
-            $this->renderGeneratedFile(
-                'DefaultController.php.twig',
-                $controllerFile,
-                $parameters
-            );
-
-            foreach ($actionProperties['views'] as $templateName) {
-                $templateFile = $dir.'/Resources/views/'.ucfirst($this->prefix).$action.'/'.$templateName.'.html.twig';
-                $this->copyPreviousFile($templateFile);
-                $this->renderGeneratedFile(
-                    'default_view.html.twig',
-                    $templateFile,
-                    $parameters + array('view' => $templateName)
-                );
-            }
         }
 
         foreach ($this->forms as $form) {
@@ -183,6 +161,33 @@ class BundleGenerator extends BaseBundleGenerator
             $generatorFile,
             $parameters
         );
+
+        if ($formsOnly) {
+            return;
+        }
+
+        foreach ($this->actions as $action => $actionProperties) {
+            $parameters['action'] = $action;
+
+            $controllerFile = $dir.'/Controller/'
+                .($this->prefix ? ucfirst($this->prefix).'/' : '').$action.'Controller.php';
+            $this->copyPreviousFile($controllerFile);
+            $this->renderGeneratedFile(
+                'DefaultController.php.twig',
+                $controllerFile,
+                $parameters
+            );
+
+            foreach ($actionProperties['views'] as $templateName) {
+                $templateFile = $dir.'/Resources/views/'.ucfirst($this->prefix).$action.'/'.$templateName.'.html.twig';
+                $this->copyPreviousFile($templateFile);
+                $this->renderGeneratedFile(
+                    'default_view.html.twig',
+                    $templateFile,
+                    $parameters + array('view' => $templateName)
+                );
+            }
+        }
     }
 
     /**

--- a/Generator/DoctrineGenerator.php
+++ b/Generator/DoctrineGenerator.php
@@ -49,41 +49,48 @@ class DoctrineGenerator extends Generator
         );
         $generator->setBaseGeneratorName($this->getBaseGeneratorName());
 
-        $builders = $generator->getFromYaml('builders', array());
+        $builders = $generator->getBuildersFromYaml();
+        $formsOnly = $generator->isFormsOnly();
 
         if (array_key_exists('list', $builders)) {
-            $generator->addBuilder(new ListBuilderAction());
-            $generator->addBuilder(new ListBuilderTemplate());
+            if (!$formsOnly) {
+                $generator->addBuilder(new ListBuilderAction());
+                $generator->addBuilder(new ListBuilderTemplate());
+            }
             $generator->addBuilder(new FiltersBuilderType());
         }
 
-        if (array_key_exists('nested_list', $builders)) {
+        if (array_key_exists('nested_list', $builders) && !$formsOnly) {
             $generator->addBuilder(new NestedListBuilderAction());
             $generator->addBuilder(new NestedListBuilderTemplate());
         }
 
         if (array_key_exists('edit', $builders)) {
-            $generator->addBuilder(new EditBuilderAction());
-            $generator->addBuilder(new EditBuilderTemplate());
+            if (!$formsOnly) {
+                $generator->addBuilder(new EditBuilderAction());
+                $generator->addBuilder(new EditBuilderTemplate());
+            }
             $generator->addBuilder(new EditBuilderType());
         }
 
         if (array_key_exists('new', $builders)) {
-            $generator->addBuilder(new NewBuilderAction());
-            $generator->addBuilder(new NewBuilderTemplate());
+            if (!$formsOnly) {
+                $generator->addBuilder(new NewBuilderAction());
+                $generator->addBuilder(new NewBuilderTemplate());
+            }
             $generator->addBuilder(new NewBuilderType());
         }
 
-        if (array_key_exists('show', $builders)) {
+        if (array_key_exists('show', $builders) && !$formsOnly) {
             $generator->addBuilder(new ShowBuilderAction());
             $generator->addBuilder(new ShowBuilderTemplate());
         }
 
-        if (array_key_exists('excel', $builders)) {
+        if (array_key_exists('excel', $builders) && !$formsOnly) {
             $generator->addBuilder(new ExcelBuilderAction());
         }
 
-        if (array_key_exists('actions', $builders)) {
+        if (array_key_exists('actions', $builders) && !$formsOnly) {
             $generator->addBuilder(new ActionsBuilderAction());
             $generator->addBuilder(new ActionsBuilderTemplate());
         }

--- a/Generator/DoctrineODMGenerator.php
+++ b/Generator/DoctrineODMGenerator.php
@@ -47,36 +47,43 @@ class DoctrineODMGenerator extends Generator
         );
         $generator->setBaseGeneratorName($this->getBaseGeneratorName());
 
-        $builders = $generator->getFromYaml('builders', array());
+        $builders = $generator->getBuildersFromYaml();
+        $formsOnly = $generator->isFormsOnly();
 
         if (array_key_exists('list', $builders)) {
-            $generator->addBuilder(new ListBuilderAction());
-            $generator->addBuilder(new ListBuilderTemplate());
+            if (!$formsOnly) {
+                $generator->addBuilder(new ListBuilderAction());
+                $generator->addBuilder(new ListBuilderTemplate());
+            }
             $generator->addBuilder(new FiltersBuilderType());
         }
 
         if (array_key_exists('edit', $builders)) {
-            $generator->addBuilder(new EditBuilderAction());
-            $generator->addBuilder(new EditBuilderTemplate());
+            if (!$formsOnly) {
+                $generator->addBuilder(new EditBuilderAction());
+                $generator->addBuilder(new EditBuilderTemplate());
+            }
             $generator->addBuilder(new EditBuilderType());
         }
 
         if (array_key_exists('new', $builders)) {
-            $generator->addBuilder(new NewBuilderAction());
-            $generator->addBuilder(new NewBuilderTemplate());
+            if (!$formsOnly) {
+                $generator->addBuilder(new NewBuilderAction());
+                $generator->addBuilder(new NewBuilderTemplate());
+            }
             $generator->addBuilder(new NewBuilderType());
         }
 
-        if (array_key_exists('show', $builders)) {
+        if (array_key_exists('show', $builders) && !$formsOnly) {
             $generator->addBuilder(new ShowBuilderAction());
             $generator->addBuilder(new ShowBuilderTemplate());
         }
 
-        if (array_key_exists('excel', $builders)) {
+        if (array_key_exists('excel', $builders) && !$formsOnly) {
             $generator->addBuilder(new ExcelBuilderAction());
         }
 
-        if (array_key_exists('actions', $builders)) {
+        if (array_key_exists('actions', $builders) && !$formsOnly) {
             $generator->addBuilder(new ActionsBuilderAction());
             $generator->addBuilder(new ActionsBuilderTemplate());
         }

--- a/Generator/PropelGenerator.php
+++ b/Generator/PropelGenerator.php
@@ -49,41 +49,48 @@ class PropelGenerator extends Generator
         $generator->setColumnClass('Admingenerator\GeneratorBundle\Generator\PropelColumn');
         $generator->setBaseGeneratorName($this->getBaseGeneratorName());
 
-        $builders = $generator->getFromYaml('builders', array());
+        $builders = $generator->getBuildersFromYaml();
+        $formsOnly = $generator->isFormsOnly();
 
         if (array_key_exists('list', $builders)) {
-            $generator->addBuilder(new ListBuilderAction());
-            $generator->addBuilder(new ListBuilderTemplate());
+            if (!$formsOnly) {
+                $generator->addBuilder(new ListBuilderAction());
+                $generator->addBuilder(new ListBuilderTemplate());
+            }
             $generator->addBuilder(new FiltersBuilderType());
         }
 
-        if (array_key_exists('nested_list', $builders)) {
+        if (array_key_exists('nested_list', $builders) && !$formsOnly) {
             $generator->addBuilder(new NestedListBuilderAction());
             $generator->addBuilder(new NestedListBuilderTemplate());
         }
 
         if (array_key_exists('edit', $builders)) {
-            $generator->addBuilder(new EditBuilderAction());
-            $generator->addBuilder(new EditBuilderTemplate());
+            if (!$formsOnly) {
+                $generator->addBuilder(new EditBuilderAction());
+                $generator->addBuilder(new EditBuilderTemplate());
+            }
             $generator->addBuilder(new EditBuilderType());
         }
 
         if (array_key_exists('new', $builders)) {
-            $generator->addBuilder(new NewBuilderAction());
-            $generator->addBuilder(new NewBuilderTemplate());
+            if (!$formsOnly) {
+                $generator->addBuilder(new NewBuilderAction());
+                $generator->addBuilder(new NewBuilderTemplate());
+            }
             $generator->addBuilder(new NewBuilderType());
         }
 
-        if (array_key_exists('show', $builders)) {
+        if (array_key_exists('show', $builders) && !$formsOnly) {
             $generator->addBuilder(new ShowBuilderAction());
             $generator->addBuilder(new ShowBuilderTemplate());
         }
 
-        if (array_key_exists('excel', $builders)) {
+        if (array_key_exists('excel', $builders) && $formsOnly) {
             $generator->addBuilder(new ExcelBuilderAction());
         }
 
-        if (array_key_exists('actions', $builders)) {
+        if (array_key_exists('actions', $builders) && !$formsOnly) {
             $generator->addBuilder(new ActionsBuilderAction());
             $generator->addBuilder(new ActionsBuilderTemplate());
         }

--- a/Resources/skeleton/bundle/generator.yml.twig
+++ b/Resources/skeleton/bundle/generator.yml.twig
@@ -4,7 +4,7 @@ params:
     namespace_prefix: {{ namespace_prefix }}
     concurrency_lock: ~
     bundle_name: {{ bundle_name }}
-    forms_only: {{ forms_only }}
+    forms_only: {{ forms_only ? 1 : 0 }}
     pk_requirement: ~
     fields: ~
     object_actions:
@@ -14,6 +14,7 @@ params:
 builders:
     list:
         params:
+            {% if not forms_only -%}
             title: List for {{ bundle_name }}
             display: ~
             actions:
@@ -21,24 +22,32 @@ builders:
             object_actions:
                 edit: ~
                 delete: ~
+            {% endif %}
+    {% if not forms_only %}
     excel:
         params: ~
         filename: ~
         filetype: ~
+    {% endif %}
     new:
         params:
+            {% if not forms_only -%}
             title: New object for {{ bundle_name }}
             display: ~
             actions:
                 save: ~
                 list: ~
+            {% endif %}
     edit:
         params:
+            {% if not forms_only -%}
             title: "You're editing the object \"%object%\"|{ %object%: {{ model_name }}.title }|"
             display: ~
             actions:
                 save: ~
                 list: ~
+            {% endif %}
+    {% if not forms_only -%}
     show:
         params:
             title: "You're viewing the object \"%object%\"|{ %object%: {{ model_name }}.title }|"
@@ -52,3 +61,4 @@ builders:
                 delete: ~
             batch_actions:
                 delete: ~
+    {% endif %}

--- a/Resources/skeleton/bundle/generator.yml.twig
+++ b/Resources/skeleton/bundle/generator.yml.twig
@@ -4,6 +4,7 @@ params:
     namespace_prefix: {{ namespace_prefix }}
     concurrency_lock: ~
     bundle_name: {{ bundle_name }}
+    forms_only: {{ forms_only }}
     pk_requirement: ~
     fields: ~
     object_actions:


### PR DESCRIPTION
This PR propose to add the `--forms-only` option to the `generate-admin` command.

If set, only forms will be generated, and not controllers and views.
This is a kind of "improve process" for embed types (you had to manually remove all unnecessary generated files by hand)
