### PR TITLE
Multi-report Excel reporting

### DIFF
--- a/Builder/Admin/ExcelBuilder.php
+++ b/Builder/Admin/ExcelBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Admingenerator\GeneratorBundle\Builder\Admin;
 
+use Admingenerator\GeneratorBundle\Generator\Column;
+
 /**
  * This builder generates php for list actions
  *
@@ -12,6 +14,11 @@ namespace Admingenerator\GeneratorBundle\Builder\Admin;
 class ExcelBuilder extends ListBuilder
 {
   /**
+   * @var array
+   */
+  protected $export = null;
+
+  /**
    * (non-PHPdoc)
    * @see Admingenerator\GeneratorBundle\Builder.BaseBuilder::getYamlKey()
    */
@@ -20,24 +27,78 @@ class ExcelBuilder extends ListBuilder
     return 'excel';
   }
 
-  public function getFileName(){
+  public function getFileName($key = null){
     if(null === ($filename = $this->getVariable('filename'))){
-      $filename = 'admin_export_'. str_replace(' ', '_', strtolower($this->getGenerator()->getFromYaml('builders.list.params.title')));
+      $filename = 'admin_export_'. str_replace(' ', '_', strtolower($this->getGenerator()->getFromYaml('builders.list.params.title'))). '.xlsx';
     }
-    return $filename;
+    return $this->getExportParamsForKey($key, 'filename', $filename);
   }
 
-  public function getFileType(){
+  public function getFileType($key = null){
     if(null === ($filetype = $this->getVariable('filetype'))){
       $filetype = 'Excel2007';
     }
-    return $filetype;
+    return $this->getExportParamsForKey($key, 'filetype', $filetype);
   }
 
-  public function getDateTimeFormat(){
+  public function getDateTimeFormat($key = null){
     if(null === ($dateTimeFormat = $this->getVariable('datetime_format'))){
       $dateTimeFormat = 'Y-m-d H:i:s';
     }
-    return $dateTimeFormat;
+    return $this->getExportParamsForKey($key, 'datetime_format', $dateTimeFormat);
   }
+
+  /**
+   * Return a list of columns from excel.export
+   * 
+   * @return array
+   */
+  public function getExport()
+  {
+      if (null === $this->export) {
+          $this->export = array();
+          $this->fillExport();
+      }
+
+      return $this->export;
+  }
+
+  protected function fillExport()
+  {
+      $export = $this->getVariable('export',[]);
+      if (!count($export)) return [];
+
+      foreach ($export as $keyName => $columns ) {
+          $params = [];
+          $this->export[$keyName] = []; 
+          if (isset($columns['display'])) {
+              $params = isset($columns['fields']) ? $columns['fields'] : [];
+              $columns = $columns['display'];
+          } 
+          foreach ($columns as $columnName) {
+              $column = $this->createColumn($columnName, false);
+              $this->setUserColumnConfiguration($column);              
+              $this->setUserExcelColumnConfiguration($column, $params);              
+              $this->export[$keyName][$columnName] = $column;
+          }
+      }
+  }
+
+  protected function setUserExcelColumnConfiguration(Column $column, array $optionsFields)
+  {
+      if (!count($optionsFields)) return;
+
+      $options = is_array($optionsFields) && array_key_exists($column->getName(), $optionsFields) ?
+          $optionsFields[$column->getName()] : array();
+
+      foreach ($options as $option => $value) {
+          $column->setProperty($option, $value);
+      }
+  }
+
+  public function getExportCredentials($key = null)
+  {
+    return $this->getExportParamsForKey($key, 'credentials', null);
+  }
+
 }

--- a/Resources/doc/admin/builder-excel.md
+++ b/Resources/doc/admin/builder-excel.md
@@ -30,7 +30,68 @@ builders:
 	  filetype: ~
 	  datetime_format: ~
 	  fields: ~
+	  export: ~
 ```
+
+#### Export
+
+This key allows to export several excel files in different formats.
+
+```yaml
+builders:
+    excel:
+        params: 
+            export:  
+                full:
+                    credentials:     'hasRole("ROLE_A")'        
+                    show_button:     false
+                    icon:            fa-files-o 
+                    label:           Full report
+                    filename:        full-report.xlsx
+                    filetype:        Excel2007
+                    datetime_format: Y-m-d H:i:s
+                    display:
+                        -            id
+                        -            title
+                        -            code
+                        -            guid
+                        -            note
+
+                short:
+                    credentials:     'hasRole("ROLE_B")'        
+                    show_button:     true
+                    icon:            fa-files-o 
+                    label:           Show report
+                    filename:        Short-repot.xls
+                    filetype:        Excel5
+                    datetime_format: d.m.Y
+                    fields:          
+                        title:
+                            label:   Product name
+                    display:
+                        -            id
+                        -            code
+                        -            title
+
+```
+
+You can customize everything includes columns, format, filename, title and even credentials.
+Also you can setup autogeneration of export buttons on list template via parameter `show_button`.
+It also auto-generates routes for each export key (if key is not found use defaults – `display`):
+
+*  /excel
+*  /excel/full
+*  /excel/short
+
+#### Show button
+
+`show_button` __default__: `true` __type__: `boolean`
+
+```yaml
+show_button: true
+```
+
+This will display button for each key (report) registered under `export` parameters key.
 
 #### Display
 

--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -11,6 +11,7 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Doctrine\Common\Util\Inflector;
 
 /**
  * @author Bob van de Vijver
@@ -25,7 +26,7 @@ class ExcelController extends \{{ namespace_prefix }}\{{ bundle_name }}\Controll
      * Generates the Excel object and send a streamed response
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function excelAction(Request $request)
+    public function excelAction(Request $request, $key = null)
     {
         $this->request = $request;
         {{ block('security_action') }}
@@ -40,15 +41,26 @@ class ExcelController extends \{{ namespace_prefix }}\{{ bundle_name }}\Controll
         $phpExcelObject = $phpexcel->createPHPExcelObject();
         $this->createExcelObject($phpExcelObject);
         $sheet = $phpExcelObject->setActiveSheetIndex(0);
+        $results = $this->getResults();
+
+        $suffix = Inflector::classify($key);
+        if (!method_exists($this,"createExcelHeader$suffix")) {
+            // back to defaults
+            $key = null;
+            $suffix = '';
+        } 
 
         // Create the first bold row in the Excel spreadsheet
-        $this->createExcelHeader($sheet);
-
+        call_user_func(array($this,"createExcelHeader$suffix"), $sheet);
         // Print the data
-        $this->createExcelData($sheet);
+        call_user_func(array($this,"createExcelData$suffix"), $sheet, $results);
+
+        $fileType = call_user_func(array($this,"getExcelFileType$suffix"));
+        $fileName = call_user_func(array($this,"getExcelFileName$suffix"), $fileType);
+        $mimeType = $this->getExcelMimeType($fileType);
 
         // Create the Writer, Response and add header
-        $writer = $phpexcel->createWriter($phpExcelObject, '{{ builder.filetype }}');
+        $writer = $phpexcel->createWriter($phpExcelObject, $fileType);
         $response = new StreamedResponse(
             function () use ($writer) {
                 $tempFile = $this->get('kernel')->getCacheDir().'/'. 
@@ -59,11 +71,52 @@ class ExcelController extends \{{ namespace_prefix }}\{{ bundle_name }}\Controll
             },
             200, array()
         );    
-        $response->headers->set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; charset=utf-8');
-        $response->headers->set('Content-Disposition', 'attachment;filename={{ builder.filename }}.xlsx');
+        $response->headers->set('Content-Type', $mimeType.'; charset=utf-8');
+        $response->headers->set('Content-Disposition', 'attachment;filename='.$fileName);
 
         return $response;
     }
+
+    protected function getExcelMimeType($fileType)
+    {
+        switch (strtoupper($fileType))
+        {
+            case 'CSV': return 'text/csv';
+            case 'PDF': return 'application/pdf';
+            case 'EXCEL5': return 'application/vnd.ms-excel';
+        }
+        return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    }
+
+    protected function getExcelExtension($fileType)
+    {
+        switch (strtoupper($fileType))
+        {
+            case 'CSV': return 'csv';
+            case 'PDF': return 'pdf';
+            case 'EXCEL5': return 'xls';
+        }
+        return 'xlsx';
+    }
+
+    protected function getExcelFileType()
+    {
+        return '{{ builder.filetype }}';
+    }
+
+    protected function getExcelFileName($fileType)
+    {
+        return $this->fixExtension('{{ builder.filename }}', $fileType);
+    }
+
+    protected function fixExtension($fileName, $fileType)
+    {
+        $path_parts = pathinfo($fileName);
+        if (!isset($path_parts['filename'])) $path_parts['filename'] = 'report';
+        $path_parts['extension'] = $this->getExcelExtension($fileType);
+        return $path_parts['filename'] . '.' . $path_parts['extension'];
+    }
+
 
     /**
      * Override this method to add your own creator, title and more to the Excel spreadsheet
@@ -79,7 +132,7 @@ class ExcelController extends \{{ namespace_prefix }}\{{ bundle_name }}\Controll
     /**
      * Fill the Excel speadsheet with the headers
      */
-    protected function createExcelheader(\PhpExcel_Worksheet $sheet)
+    protected function createExcelHeader(\PhpExcel_Worksheet $sheet)
     {
         $translator = $this->get('translator');
 
@@ -104,10 +157,9 @@ class ExcelController extends \{{ namespace_prefix }}\{{ bundle_name }}\Controll
     /**
      * Fills the Excel spreadsheet with data
      */
-    protected function createExcelData(\PhpExcel_Worksheet $sheet)
+    protected function createExcelData(\PhpExcel_Worksheet $sheet, $results)
     {
         $row = 2;
-        $results = $this->getResults();
 
         foreach($results as ${{ builder.ModelClass }}) {
             $colNum = 0;
@@ -138,6 +190,86 @@ class ExcelController extends \{{ namespace_prefix }}\{{ bundle_name }}\Controll
         }
     }
     
+{% for keyname, columns in builder.export %}
+
+    /**
+     * Fill the Excel speadsheet with the headers for {{ keyname }}
+     */
+    protected function createExcelHeader{{ keyname|classify|php_name }}(\PhpExcel_Worksheet $sheet)
+    {
+        {% set credentials = builder.exportCredentials(keyname) %}
+        {{ block('security_action') }}
+
+        $translator = $this->get('translator');
+
+        $colNum = 0;
+        {% for column in columns %}
+            {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
+            {% set credentials = column.credentials %}
+            if ($this->validateCredentials('{{ credentials }}')) {
+            {% endif %}
+            $sheet->setCellValueByColumnAndRow($colNum, 1, $translator->trans("{{ column.label }}", array(), '{{ i18n_catalog|default("Admin") }}'), true);
+            $columnLetter = \PHPExcel_Cell::stringFromColumnIndex($colNum);
+            $sheet->getStyle($columnLetter . '1')->getFont()->setBold(true);
+            $sheet->getColumnDimension($columnLetter)->setAutoSize(true);
+
+            $colNum++;
+            {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
+            }
+            {% endif %}
+        {% endfor %}
+    }
+
+    /**
+     * Fills the Excel spreadsheet with data for {{ keyname }}
+     */
+    protected function createExcelData{{ keyname|classify|php_name }}(\PhpExcel_Worksheet $sheet, $results)
+    {
+        $row = 2;
+
+        foreach($results as ${{ builder.ModelClass }}) {
+            $colNum = 0;
+            {% for name,column in columns %}
+                {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
+                    {% set credentials = column.credentials %}
+                if ($this->validateCredentials('{{ credentials }}', ${{ builder.ModelClass }})) {
+                {% endif %}
+                $data = $this->getValueForCell('{{ column.getter }}', ${{ builder.ModelClass }});
+                $formatedValue = $this->format{{ name|classify|php_name }}($data);
+
+                // Convert DateTime object to given format
+                if ($formatedValue instanceof \DateTime){
+                    $formatedValue = $formatedValue->format('{{ builder.dateTimeFormat(keyname) }}');
+                }
+
+                $sheet->setCellValueByColumnAndRow($colNum, $row, $formatedValue);
+                {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
+                }
+                {% endif %}
+            // Inc is outside of the credentials check to be sync with headers.
+            // Otherwise if column X is authorized but depending on object, there will
+            // be some offset. Putting inc outise of the check will always update it.
+            $colNum++;
+            {% endfor %}
+
+            $row++;
+        }
+    }
+
+    protected function getExcelFileType{{ keyname|classify|php_name }}()
+    {
+        return '{{ builder.filetype(keyname) }}';
+    }
+
+    protected function getExcelFileName{{ keyname|classify|php_name }}($fileType)
+    {
+        return $this->fixExtension('{{ builder.filename(keyname) }}', $fileType);
+    }
+
+
+{% endfor %}
+
+
     /**
      * Gets the value from the given field that will be place at an Excel cell
      *

--- a/Resources/templates/CommonAdmin/generic_actions.php.twig
+++ b/Resources/templates/CommonAdmin/generic_actions.php.twig
@@ -9,13 +9,22 @@
                     {{ echo_if('is_one_admingenerator_granted(actionCredentials)') }}
                 {% endif %}
 
+                {% set excelActions = builder.excelActions is defined ? builder.excelActions : [] %}
                 {% for action in builder.Actions %}
                     {{ echo_block("generic_action_" ~ action.twigName) }}
                     {% if action.credentials %}
                         {{ echo_if_granted(action.credentials) }}
                     {% endif %}
 
-                    {{ block('generic_action_block') }}
+                    {% if action.name is same as('excel') and excelActions|length %}
+
+                        {{ block('generic_action_excel_block') }}
+
+                    {% else %}
+
+                        {{ block('generic_action_block') }}
+
+                    {% endif %}
 
                     {% if action.credentials %}
                         {{ echo_endif() }}
@@ -48,6 +57,43 @@
           {%- if action.icon %}<i class="fa fa-fw {{ action.icon|default }}"></i> {% endif %}{{ echo_trans(action.label, {}, translationDomain) }}
         </a>
     {% endif %}
+{% endblock %}
+
+{% block generic_action_excel_block %}
+    {% set actionRoute = action.route ? action.route : builder.baseActionsRoute ~ '_' ~ action.name %}
+    {% set actionParams = action.params ? echo_twig_assoc(action.params) : "{}" %}
+    {% set translationDomain = action.type is same as('custom') ? i18n_catalog|default("Admin") : 'Admingenerator' %}
+
+        <div class="btn-group">
+           <button type="button" class="generic-action btn {{ action.class|default('btn-default') }}" data-toggle="dropdown" aria-expanded="false">
+              <i class="fa fa-fw {{ action.icon|default }}"></i> {{ echo_trans('action.generic.export', {}, 'Admingenerator') }} 
+              <span class="caret"></span>
+           </button>
+           <ul class="dropdown-menu dropdown-menu-right" role="menu">
+              <li><a class="generic-action btn {{ action.class|default('btn-default') }}" href="{{ echo_path(actionRoute, actionParams) }}"
+          {%- if action.confirm %} data-confirm="{{ echo_trans(action.confirm, {}, translationDomain, 'html_attr') }}"{% endif %}
+          {%- if action.csrfProtected %} data-csrf-token="{{ echo_path(actionRoute, actionParams, ['csrf_token']) }}" {% endif -%}>
+          {%- if action.icon %}<i class="fa fa-fw {{ action.icon|default }}"></i> {% endif %}{{ echo_trans(action.label, {}, translationDomain) }}</a></li>
+    
+    {% for keyName, eaction in excelActions %}
+
+      {% if eaction.credentials %}
+          {{ echo_if_granted(eaction.credentials) }}
+      {% endif %}
+
+        <li><a class="generic-action btn {{ eaction.class|default('btn-default') }}" href="{{ echo_path(actionRoute, echo_twig_assoc({ key: keyName })) }}"
+          {%- if action.confirm %} data-confirm="{{ echo_trans(action.confirm, {}, translationDomain, 'html_attr') }}"{% endif -%}>
+          {%- if eaction.icon %}<i class="fa fa-fw {{ eaction.icon|default }}"></i> {% endif %}{{ echo_trans(eaction.label, {}, translationDomain) }}
+        </a></li>
+
+      {% if eaction.credentials %}
+          {{ echo_endif() }}
+      {% endif %}
+
+    {% endfor %}                
+           </ul>
+        </div>
+                
 {% endblock %}
 
 {% block generic_actions_script %}

--- a/Resources/translations/Admingenerator.de.yml
+++ b/Resources/translations/Admingenerator.de.yml
@@ -51,7 +51,8 @@ action.generic:
     save-and-list:  Speichern und Übersicht
     save-and-show:  Speichern und zeigen
     excel:  Export to Excel
-
+    export: Export
+    
 # Object actions
 action.object.edit:
     label:    Bearbeiten

--- a/Resources/translations/Admingenerator.en.yml
+++ b/Resources/translations/Admingenerator.en.yml
@@ -52,6 +52,7 @@ action.generic:
     save-and-list:  Save and list
     save-and-show:  Save and show
     excel:  Export to Excel
+    export: Export
 
 # Object actions
 action.object.edit:

--- a/Resources/translations/Admingenerator.es.yml
+++ b/Resources/translations/Admingenerator.es.yml
@@ -52,6 +52,7 @@ action.generic:
     save-and-list:  Guardar y listar
     save-and-show:  Guardar y mostrar
     excel:  Export to Excel
+    export: Export
 
 # Object actions
 action.object.edit:

--- a/Resources/translations/Admingenerator.fa.yml
+++ b/Resources/translations/Admingenerator.fa.yml
@@ -51,6 +51,7 @@ action.generic:
     save-and-list:  ذخیره و لیست
     save-and-show:  ذخیره و نشان
     excel:  Export to Excel
+    export: Export
 
 # Object actions
 action.object.edit:

--- a/Resources/translations/Admingenerator.fr.yml
+++ b/Resources/translations/Admingenerator.fr.yml
@@ -50,7 +50,8 @@ action.generic:
     save-and-add:   Enregistrer et Nouveau
     save-and-list:  Enregistrer et Retour à la liste
     save-and-show:  Enregistrer et montrer
-    excel:  Export to Excel
+    excel:  Exporter au format Excel
+    export: Exporter
 
 # Object actions
 action.object.edit:

--- a/Resources/translations/Admingenerator.it.yml
+++ b/Resources/translations/Admingenerator.it.yml
@@ -51,6 +51,7 @@ action.generic:
     save-and-list:  Salva e Lista
     save-and-show:  Salva e Mostrare
     excel:  Export to Excel
+    export: Export
 
 # Object actions
 action.object.edit:

--- a/Resources/translations/Admingenerator.ja.yml
+++ b/Resources/translations/Admingenerator.ja.yml
@@ -51,6 +51,7 @@ action.generic:
     save-and-list:  保存して戻る
     save-and-show:  保存して表示
     excel:  Excel へのエクスポート
+    export: Export
 
 # Object actions
 action.object.edit:

--- a/Resources/translations/Admingenerator.nl.yml
+++ b/Resources/translations/Admingenerator.nl.yml
@@ -51,6 +51,7 @@ action.generic:
     save-and-list:  Opslaan en naar lijst
     save-and-show:  Opslaan en tonen
     excel:  Exporteren naar Excel
+    export: Exporteren
 
 # Object actions
 action.object.edit:

--- a/Resources/translations/Admingenerator.pl.yml
+++ b/Resources/translations/Admingenerator.pl.yml
@@ -51,6 +51,7 @@ action.generic:
     save-and-list:  Zapisz i Lista
     save-and-show:  Zapisz i Pokazać
     excel:          Eksportuj
+    export:         Eksportuj
 
 # Object actions
 action.object.edit:

--- a/Resources/translations/Admingenerator.pt.yml
+++ b/Resources/translations/Admingenerator.pt.yml
@@ -51,6 +51,7 @@ action.generic:
     save-and-list:  Salvar e Listar
     save-and-show:  Salvar e Mostrar
     excel:  Excelar a Excel
+    export:  Excelar
 
 # Object actions
 action.object.edit:

--- a/Resources/translations/Admingenerator.ro.yml
+++ b/Resources/translations/Admingenerator.ro.yml
@@ -51,6 +51,7 @@ action.generic:
     save-and-list:  Lista și Salvare
     save-and-show:  Arată și Salvare
     excel:  Export în Excel
+    export:  Export
 
 # Object actions
 action.object.edit:

--- a/Resources/translations/Admingenerator.ru.yml
+++ b/Resources/translations/Admingenerator.ru.yml
@@ -52,7 +52,8 @@ action.generic:
     save-and-list:  Сохранить и Список
     save-and-show:  Cохранить и показать
     excel:  Экспорт в Excel
-
+    export: Экспорт
+    
 # Object actions
 action.object.edit:
     label:    Редактировать

--- a/Resources/translations/Admingenerator.sl.yml
+++ b/Resources/translations/Admingenerator.sl.yml
@@ -51,6 +51,7 @@ action.generic:
     save-and-list:  Shrani in Seznam
     save-and-show:  Shrani in Prikaz
     excel:  Izvoz v Excel
+    export: Izvoz
 
 # Object actions
 action.object.edit:

--- a/Resources/translations/Admingenerator.tr.yml
+++ b/Resources/translations/Admingenerator.tr.yml
@@ -43,6 +43,7 @@ action.generic:
     save-and-list:  Kaydet ve Listeye Dön
     save-and-show:  Kaydet ve Göstermek
     excel:  Excel'e verme
+    export:  Verme
 
 # Object actions
 action.object.edit:

--- a/Resources/translations/Admingenerator.uk.yml
+++ b/Resources/translations/Admingenerator.uk.yml
@@ -50,6 +50,7 @@ action.generic:
     save-and-list:  Зберегти та список
     save-and-show:  Зберегти та показати
     excel:  Експорт в Excel
+    export: Експорт
 
 # Object actions
 action.object.edit:

--- a/Routing/RoutingLoader.php
+++ b/Routing/RoutingLoader.php
@@ -21,8 +21,8 @@ class RoutingLoader extends FileLoader
             'methods'      => array('GET'),
         ),
         'excel'=> array(
-            'path'         => '/excel',
-            'defaults'     => array(),
+            'path'         => '/excel/{key}',
+            'defaults'     => array('key'=>null),
             'requirements' => array(),
             'methods'      => array('GET'),
             'controller'   => 'excel',


### PR DESCRIPTION
There are still no GUI, no credentials or other parameters merging as we discuss before in #262 .

It auto-generates routes for each export key (if key is not found use defaults). 
*  /excel
*  /excel/full
*  /excel/short
*  /excel/simple

Please, add download buttons to UI manualy. 

Simple YAML config (only columns, it's cover 99% of my needs FOR NOW):
```yaml
    excel:
        params: 
            export: 
               full:
                -       id
                -       title
                -       code
                -       guid
                -       note
               short:
                -       id
                -       code
                -       title
               simple:
                -       title
```
Demo available at https://github.com/ksn135/s2a-multi-report