### PR TITLE
fixing dbType array when using propel

### DIFF
--- a/Guesser/PropelORMFieldGuesser.php
+++ b/Guesser/PropelORMFieldGuesser.php
@@ -325,15 +325,21 @@ class PropelORMFieldGuesser
         if (preg_match("#CollectionType$#i", $type)) {
             $relation = $this->getRelation($columnName, $class);
 
+            if ($relation) {
+                return array(
+                    'allow_add'     => true,
+                    'allow_delete'  => true,
+                    'by_reference'  => false,
+                    'entry_type' => 'entity',
+                    'entry_options' => array(
+                        'class' => \RelationMap::MANY_TO_ONE === $relation->getType() ? $relation->getForeignTable()->getClassname() : $relation->getLocalTable()->getClassname()
+                    )
+                );
+            }
+            
             return array(
-                'allow_add'     => true,
-                'allow_delete'  => true,
-                'by_reference'  => false,
-                'entry_type' => 'entity',
-                'entry_options' => array(
-                    'class' => \RelationMap::MANY_TO_ONE === $relation->getType() ? $relation->getForeignTable()->getClassname() : $relation->getLocalTable()->getClassname()
-                )
-            );
+                    'entry_type' => 'text',
+                );
         }
 
         if (\PropelColumnTypes::ENUM == $dbType) {


### PR DESCRIPTION
When using Propel, and having a column with the type "array", in the function getOptions the parameter type is CollectionType.
When having a CollectionType, it is considering that we have always a relation but in the case using an array we havent. So a exception is thrown saying that we are calling getType on a boolean variable.

The fix is :
```

if (preg_match("#CollectionType$#i", $type)) {
            $relation = $this->getRelation($columnName, $class);

++            if ($relation) {
                return array(
                    'allow_add'     => true,
                    'allow_delete'  => true,
                    'by_reference'  => false,
                    'entry_type' => 'entity',
                    'entry_options' => array(
                        'class' => \RelationMap::MANY_TO_ONE === $relation->getType() ? $relation->getForeignTable()->getClassname() : $relation->getLocalTable()->getClassname()
                    )
                );
++            }
            
++            return array(
++                   'entry_type' => 'text',
++               );
        }


```