### PR TITLE
FIX: allow to use array as field values in scope filters

### DIFF
--- a/Resources/templates/CommonAdmin/ListAction/scopes.php.twig
+++ b/Resources/templates/CommonAdmin/ListAction/scopes.php.twig
@@ -106,7 +106,7 @@
                 {% if params["filters"] is defined -%}
                     {%- for filter, filterParams in params["filters"] -%}
                         {%- if not filter|is_numeric -%}
-                            $filters['{{ filter }}'] = '{{ filterParams }}';
+                            $filters['{{ filter }}'] = {{ filterParams|as_php }};
                         {%- endif -%}
                     {%- endfor -%}
                 {%- endif %}


### PR DESCRIPTION
In my case I need to use several states (array) in filter to achieve required functionality (as it always works for me before in previous versions).
Without this fix `cache:clear` throws exception `>> Skip warmup An exception has been thrown during the rendering of a template ("Notice: Array to string conversion") in "../CommonAdmin/ListAction/scopes.php.twig".`
Example:
```yaml

            scopes:
                group_1: 
                    "Все": 
                        default: true
                        filters: 
                            -      notArchive
                    "Ждут согласования": 
                        filters: 
                            state: [draft, declined, checked]
                    "У Куратора": 
                        filters: 
                            state: reviewed
                    "В Бухгалтерии": 
                        filters: 
                            state: accounted
                    "В ФинСлужбе": 
                        filters: 
                            state: appointed
                    "В Казначействе": 
                        filters: 
                            state: treasured
                    "Ожидают оплаты": 
                        filters: 
                            state: suspended
                            1:     notToday
                    "Оплаты на сегодня": 
                        filters: 
                            state: suspended
                            1:     today
                    "В Реестре на сегодня": 
                        filters: 
                            state: approved
                    "В 1С": 
                        filters: 
                            state: [assigned, uploaded, sended, cashed]
                    "Оплата не возможна": 
                        filters: 
                            state: canceled
                    "Оплачено": 
                        filters: 
                            state: payed
                    "Архив": 
                        filters: 
                            state: archive

                group_2: 
                    "Не важно": 
                        default: true
                        filters: ~
                    "Без договора": 
                        filters: 
                            bargainSendTo1CState:  none
                    "На создании": 
                        filters: 
                            bargainSendTo1CState:  draft
                    "На согласовании": 
                        filters: 
                            bargainSendTo1CState:  concordance
                    "Согласован": 
                        filters: 
                            bargainSendTo1CState:  done

```