### PR TITLE
Issue #186 : allows "array" db type to be used with a collection form type

### DIFF
--- a/Guesser/DoctrineFieldGuesser.php
+++ b/Guesser/DoctrineFieldGuesser.php
@@ -286,17 +286,21 @@ abstract class DoctrineFieldGuesser
         }
 
         if (preg_match("/CollectionType$/i", $type)) {
-            $mapping = $this->getMetadatas($class)->getAssociationMapping($columnName);
-
-            return array(
+            $options = array(
                 'allow_add'     => true,
                 'allow_delete'  => true,
                 'by_reference'  => false,
                 'entry_type' => $filter ? $this->filterTypes[$this->objectModel] : $this->formTypes[$this->objectModel],
-                'entry_options' => array(
-                    'class' => $mapping['target'.ucfirst($this->objectModel)]
-                )
             );
+
+            if ($this->getMetadatas($class)->hasAssociation($columnName)) {
+                $mapping = $this->getMetadatas($class)->getAssociationMapping($columnName);
+                $options['entry_options'] = array(
+                    'class' => $mapping['target'.ucfirst($this->objectModel)]
+                );
+            }
+
+            return $options;
         }
 
         return array(


### PR DESCRIPTION
Collection types currently have to have a Doctrine mapping association. That makes simple array type unable to be used as a collection type. 

In this "fix", we check, when there is a collection type, if the column has a mapping association before getting it, to avoid the "No mapping found" error reported here : https://github.com/symfony2admingenerator/GeneratorBundle/issues/186

