### PR TITLE
Finder short circuit if path is not a dir

### DIFF
--- a/Filesystem/GeneratorsFinder.php
+++ b/Filesystem/GeneratorsFinder.php
@@ -66,7 +66,7 @@ class GeneratorsFinder
     {
         $yamls =  array();
 
-        if (!file_exists($bundle->getPath().'/Resources/config')) {
+        if (!is_dir($bundle->getPath().'/Resources/config')) {
             return $yamls;
         }
 


### PR DESCRIPTION
I think we should check here for `is_dir` instead of simply `file_exists`. If there is no directory, there is no need to instantiate Finder object.