### PR TITLE
Fixed #312, UUID can be used for entity IDs.

### DIFF
--- a/Resources/templates/CommonAdmin/EditTemplate/EditBuilderTemplate.php.twig
+++ b/Resources/templates/CommonAdmin/EditTemplate/EditBuilderTemplate.php.twig
@@ -23,7 +23,7 @@
 {{ echo_block("page_content") }}
     <div class="row">
         <div class="form-model form-model-{{ builder.modelClass|lower }} col-md-12">
-            {{ echo_if(builder.ModelClass ~ "." ~ builder.getFieldGuesser().getModelPrimaryKeyName(model)) }}
+            {{ echo_if('updateUrl is defined') }}
                 {{ echo_set("attr", "{'class': 'form-model-update', 'action': updateUrl}|merge(form.vars.attr|default({}))", false) }}
             {{ echo_else() }}
                 {{ echo_set("attr", "{'class': 'form-model-new', 'action': createUrl}|merge(form.vars.attr|default({}))", false) }}


### PR DESCRIPTION
Fix for https://github.com/symfony2admingenerator/GeneratorBundle/issues/312.

Controllers will send either `updateUrl` or `createUrl`, so that is reliable source which controller is being used (edit or new) in order to generate appropriate route.

In that matter, pre-generated entity ID (such as UUID) can be used safely. 

NOTE: This PR does not introduces BC breaks.