### PR TITLE
Prevent double translation in Filter form label by treating it the same as edit or new form labels

### DIFF
--- a/Resources/templates/CommonAdmin/ListTemplate/FiltersBuilderTemplate.php.twig
+++ b/Resources/templates/CommonAdmin/ListTemplate/FiltersBuilderTemplate.php.twig
@@ -54,9 +54,7 @@
                             {% endif %}
                             <div class="list-filters-field-{{ column.name|lower }} list-filters-type-{{ column.filterType|lower }}">
                                 {{ echo_block("list_filters_field_" ~ (column.name|lower) ~ "_content" ) }}
-                                {{ echo_twig("form_label(form['" ~ column.name ~ "'], '" ~ builder.FilterColumns[column.name].label|addslashes ~ "'|trans({}, '" ~ i18n_catalog|default("Admin") ~ "'))") }}
-                                {{ echo_twig("form_widget(form['" ~ column.name ~ "'])") }}
-                                {{ echo_twig("form_errors(form['" ~ column.name ~ "'], {'attr': {'class': 'form-control-feedback'}})") }}
+                                {{ echo_twig("form_row(form['" ~ column.name ~ "'])") }}
                                 {{ echo_endblock() }}
                             </div>
                             {% if column.filtersCredentials is not empty %}

--- a/UPGRADE.MD
+++ b/UPGRADE.MD
@@ -8,6 +8,7 @@ This page contains all upgrade notes since the release of the stable 2.0.0 versi
 
 ## Current `master` branch
 
+- In order to keep form label translation behavior consistent, filter form labels are no longer translated. This can be achieved by performing this translation in the project, which was already needed for new and edit form labels.
 - Form type service names will be generated based on form FQCN instead of model FQCN. Old naming is aliased to new service name to not have BC break.
 - Fixed [#285](https://github.com/symfony2admingenerator/GeneratorBundle/issues/285): added cookbook entry regarding injection
   of additional services in form types. Documented method of registration of auto generated form types in service container.


### PR DESCRIPTION
Filter form labels are translated by default, which could lead to double translations if the project also implements translation of form labels.
However, edit and new forms do not do this translation, leading to inconsistent behavior.

This PR proposes a change in the build-up of form rows in the filter form, making the behavior for new, edit and filter forms the same.
It seems that some 'functionality' is lost (being able to give the filter form row a different label than the other forms), but this can easily be achieved by passing the label in the filterOptions or by changing it in the list builder.
Therefore, no real functionality is lost.
