### PR TITLE
Implement PHPSpreadsheet compatibility

### DIFF
--- a/Builder/Admin/ExcelBuilder.php
+++ b/Builder/Admin/ExcelBuilder.php
@@ -36,7 +36,12 @@ class ExcelBuilder extends ListBuilder
 
   public function getFileType($key = null){
     if(null === ($filetype = $this->getVariable('filetype'))){
-      $filetype = 'Excel2007';
+      if(class_exists('\PhpOffice\PhpSpreadsheet\Spreadsheet'))
+      {
+        $filetype = 'Xlsx';
+      } else {
+        $filetype = 'Excel2007';
+      }
     }
     return $this->getExportParamsForKey($key, 'filetype', $filetype);
   }

--- a/Resources/doc/admin/builder-excel.md
+++ b/Resources/doc/admin/builder-excel.md
@@ -48,7 +48,7 @@ builders:
                     icon:            fa-files-o 
                     label:           Full report
                     filename:        full-report.xlsx
-                    filetype:        Excel2007
+                    filetype:        Xlsx
                     datetime_format: Y-m-d H:i:s
                     display:
                         -            id
@@ -63,7 +63,7 @@ builders:
                     icon:            fa-files-o 
                     label:           Show report
                     filename:        Short-repot.xls
-                    filetype:        Excel5
+                    filetype:        Xls
                     datetime_format: d.m.Y
                     fields:          
                         title:
@@ -117,7 +117,7 @@ Specify the export filename. When null 'admin_export_{list title}' is used.
 
 `filetype` __default__: `Excel2007` __type__: `string`
 
-Default Excel2007. See the [excelbundle documention](https://github.com/liuggio/excelbundle#not-only-excel5) for the 
+Default Xlsx. See the [PHPSpreadsheet documention](https://phpspreadsheet.readthedocs.io/en/develop/topics/file-formats/) for the 
 possible options.
 
 #### Datetime format

--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -46,51 +46,283 @@ class ExcelController extends \{{ namespace_prefix }}\{{ bundle_name }}\Controll
           {% endfor %}
         }
 
-        // Create the PHPExcel object with some standard values
-        try {
-          $phpexcel = $this->get('phpexcel');
-        } catch (ServiceNotFoundException $e){
-          throw new \Exception('You will need to enable the PHPExcel bundle for this function to work.', null, $e);
+        if(class_exists('\PhpOffice\PhpSpreadsheet\Spreadsheet')) {
+          $spreadsheet = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
+          $this->createSpreadsheetObject($spreadsheet);
+          $sheet = $spreadsheet->setActiveSheetIndex(0);
+          $results = $this->getResults();
+
+          $suffix = Inflector::classify($key);
+          if (!method_exists($this,"createSpreadsheetHeader$suffix")) {
+              // back to defaults
+              $key = null;
+              $suffix = '';
+          }
+
+          // Create the first bold row in the Excel spreadsheet
+          call_user_func(array($this,"createSpreadsheetHeader$suffix"), $sheet);
+          // Print the data
+          call_user_func(array($this,"createSpreadsheetData$suffix"), $sheet, $results);
+
+          $fileType = call_user_func(array($this,"getSpreadsheetFileType$suffix"));
+          $fileName = call_user_func(array($this,"getSpreadsheetFileName$suffix"), $fileType);
+          $mimeType = $this->getSpreadsheetMimeType($fileType);
+
+          // Create the Writer, Response and add header
+          $writer = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($spreadsheet, $fileType);
+          $response = new StreamedResponse(
+              function () use ($writer) {
+                  $tempFile = $this->get('kernel')->getCacheDir().'/'.
+                  rand(0, getrandmax()).rand(0, getrandmax()).".tmp";
+                  $writer->save($tempFile);
+                  readfile($tempFile);
+                  unlink($tempFile);
+              },
+              200, array()
+          );
+          $response->headers->set('Content-Type', $mimeType.'; charset=utf-8');
+          $response->headers->set('Content-Disposition', 'attachment;filename='.$fileName);
+
+          return $response;
+        } else {
+          // Create the PHPExcel object with some standard values
+          try {
+            $phpexcel = $this->get('phpexcel');
+          } catch (ServiceNotFoundException $e){
+            throw new \Exception('You will need to enable the PHPExcel bundle or install phpspreadsheet for this function to work.', null, $e);
+          }
+
+          $phpExcelObject = $phpexcel->createPHPExcelObject();
+          $this->createExcelObject($phpExcelObject);
+          $sheet = $phpExcelObject->setActiveSheetIndex(0);
+          $results = $this->getResults();
+
+          $suffix = Inflector::classify($key);
+          if (!method_exists($this,"createExcelHeader$suffix")) {
+              // back to defaults
+              $key = null;
+              $suffix = '';
+          }
+
+          // Create the first bold row in the Excel spreadsheet
+          call_user_func(array($this,"createExcelHeader$suffix"), $sheet);
+          // Print the data
+          call_user_func(array($this,"createExcelData$suffix"), $sheet, $results);
+
+          $fileType = call_user_func(array($this,"getExcelFileType$suffix"));
+          $fileName = call_user_func(array($this,"getExcelFileName$suffix"), $fileType);
+          $mimeType = $this->getExcelMimeType($fileType);
+
+          // Create the Writer, Response and add header
+          $writer = $phpexcel->createWriter($phpExcelObject, $fileType);
+          $response = new StreamedResponse(
+              function () use ($writer) {
+                  $tempFile = $this->get('kernel')->getCacheDir().'/'.
+                      rand(0, getrandmax()).rand(0, getrandmax()).".tmp";
+                  $writer->save($tempFile);
+                  readfile($tempFile);
+                  unlink($tempFile);
+              },
+              200, array()
+          );
+          $response->headers->set('Content-Type', $mimeType.'; charset=utf-8');
+          $response->headers->set('Content-Disposition', 'attachment;filename='.$fileName);
+
+          return $response;
         }
-
-        $phpExcelObject = $phpexcel->createPHPExcelObject();
-        $this->createExcelObject($phpExcelObject);
-        $sheet = $phpExcelObject->setActiveSheetIndex(0);
-        $results = $this->getResults();
-
-        $suffix = Inflector::classify($key);
-        if (!method_exists($this,"createExcelHeader$suffix")) {
-            // back to defaults
-            $key = null;
-            $suffix = '';
-        } 
-
-        // Create the first bold row in the Excel spreadsheet
-        call_user_func(array($this,"createExcelHeader$suffix"), $sheet);
-        // Print the data
-        call_user_func(array($this,"createExcelData$suffix"), $sheet, $results);
-
-        $fileType = call_user_func(array($this,"getExcelFileType$suffix"));
-        $fileName = call_user_func(array($this,"getExcelFileName$suffix"), $fileType);
-        $mimeType = $this->getExcelMimeType($fileType);
-
-        // Create the Writer, Response and add header
-        $writer = $phpexcel->createWriter($phpExcelObject, $fileType);
-        $response = new StreamedResponse(
-            function () use ($writer) {
-                $tempFile = $this->get('kernel')->getCacheDir().'/'. 
-                    rand(0, getrandmax()).rand(0, getrandmax()).".tmp";
-                $writer->save($tempFile);
-                readfile($tempFile);
-                unlink($tempFile);
-            },
-            200, array()
-        );    
-        $response->headers->set('Content-Type', $mimeType.'; charset=utf-8');
-        $response->headers->set('Content-Disposition', 'attachment;filename='.$fileName);
-
-        return $response;
     }
+
+    protected function getSpreadsheetMimeType($fileType)
+    {
+        switch (strtoupper($fileType))
+        {
+            case 'Csv': return 'text/csv';
+            case 'Pdf': return 'application/pdf';
+            case 'Xls': return 'application/vnd.ms-excel';
+        }
+        return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    }
+
+    protected function getSpreadsheetExtension($fileType)
+    {
+        switch (strtoupper($fileType))
+        {
+            case 'Csv': return 'csv';
+            case 'Pdf': return 'pdf';
+            case 'Xls': return 'xls';
+        }
+        return 'xlsx';
+    }
+
+    protected function getSpreadsheetFileType()
+    {
+        return '{{ builder.filetype }}';
+    }
+
+    protected function getSpreadsheetFileName($fileType)
+    {
+        return $this->fixSpreadsheetExtension('{{ builder.filename }}', $fileType);
+    }
+
+    protected function fixSpreadsheetExtension($fileName, $fileType)
+    {
+        $path_parts = pathinfo($fileName);
+        if (!isset($path_parts['filename'])) $path_parts['filename'] = 'report';
+        $path_parts['extension'] = $this->getSpreadsheetExtension($fileType);
+        return $path_parts['filename'] . '.' . $path_parts['extension'];
+    }
+
+
+    /**
+    * Override this method to add your own creator, title and more to the spreadsheet
+    */
+    protected function createSpreadsheetObject(\PhpOffice\PhpSpreadsheet\Spreadsheet $spreadsheet)
+    {
+        $spreadsheet->getProperties()->setCreator("AdminGeneratorBundle")
+        ->setTitle('AdminGenerator Excel Export')
+        ->setSubject("AdminGenerator Excel Export")
+        ->setDescription("AdminGenerator Excel export");
+    }
+
+    /**
+    * Fill the spreadsheet with the headers
+    */
+    protected function createSpreadsheetHeader(\PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet)
+    {
+        $translator = $this->get('translator');
+
+        $colNum = 1;
+        {% for column in builder.columns %}
+          {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
+            {% set credentials = column.credentials %}
+            if ($this->validateCredentials('{{ credentials }}')) {
+          {% endif %}
+          $sheet->setCellValueByColumnAndRow($colNum, 1, $translator->trans("{{ column.label }}", array(), '{{ i18n_catalog|default("Admin") }}'));
+          $columnLetter = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($colNum);
+          $sheet->getStyle($columnLetter . '1')->getFont()->setBold(true);
+          $sheet->getColumnDimension($columnLetter)->setAutoSize(true);
+
+          $colNum++;
+          {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
+            }
+          {% endif %}
+        {% endfor %}
+    }
+
+    /**
+    * Fills the Excel spreadsheet with data
+    */
+    protected function createSpreadsheetData(\PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet, $results)
+    {
+        $row = 2;
+
+        foreach($results as ${{ builder.ModelClass }}) {
+            $colNum = 1;
+            {% for name,column in builder.columns %}
+              {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
+                {% set credentials = column.credentials %}
+                if ($this->validateCredentials('{{ credentials }}', ${{ builder.ModelClass }})) {
+              {% endif %}
+              $data = $this->getValueForCell('{{ column.getter }}', ${{ builder.ModelClass }});
+              $formattedValue = $this->format{{ name|classify|php_name }}($data);
+
+              // Convert DateTime object to given format
+              if ($formattedValue instanceof \DateTime){
+                  $formattedValue = $formattedValue->format('{{ builder.dateTimeFormat }}');
+              }
+
+              $sheet->setCellValueByColumnAndRow($colNum, $row, $formattedValue);
+              {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
+                }
+              {% endif %}
+              // Inc is outside of the credentials check to be sync with headers.
+              // Otherwise if column X is authorized but depending on object, there will
+              // be some offset. Putting inc outise of the check will always update it.
+              $colNum++;
+            {% endfor %}
+
+            $row++;
+        }
+    }
+
+{% for keyname, columns in builder.export %}
+
+  /**
+  * Fill the spreadsheet with the headers for {{ keyname }}
+  */
+  protected function createSpreadsheetHeader{{ keyname|classify|php_name }}(\PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet)
+  {
+      {% set credentials = builder.exportCredentials(keyname) %}
+      {{ block('security_action') }}
+
+      $translator = $this->get('translator');
+
+      $colNum = 1;
+      {% for column in columns %}
+        {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
+          {% set credentials = column.credentials %}
+          if ($this->validateCredentials('{{ credentials }}')) {
+        {% endif %}
+        $sheet->setCellValueByColumnAndRow($colNum, 1, $translator->trans("{{ column.label }}", array(), '{{ i18n_catalog|default("Admin") }}'), true);
+        $columnLetter = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($colNum);
+        $sheet->getStyle($columnLetter . '1')->getFont()->setBold(true);
+        $sheet->getColumnDimension($columnLetter)->setAutoSize(true);
+
+        $colNum++;
+        {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
+          }
+        {% endif %}
+      {% endfor %}
+  }
+
+  /**
+  * Fills the spreadsheet with data for {{ keyname }}
+  */
+  protected function createSpreadsheetData{{ keyname|classify|php_name }}(\PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet, $results)
+  {
+      $row = 2;
+
+      foreach($results as ${{ builder.ModelClass }}) {
+          $colNum = 1;
+          {% for name,column in columns %}
+            {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
+              {% set credentials = column.credentials %}
+              if ($this->validateCredentials('{{ credentials }}', ${{ builder.ModelClass }})) {
+            {% endif %}
+            $data = $this->getValueForCell('{{ column.getter }}', ${{ builder.ModelClass }});
+            $formattedValue = $this->format{{ name|classify|php_name }}($data);
+
+            // Convert DateTime object to given format
+            if ($formattedValue instanceof \DateTime){
+            $formattedValue = $formattedValue->format('{{ builder.dateTimeFormat(keyname) }}');
+            }
+
+            $sheet->setCellValueByColumnAndRow($colNum, $row, $formattedValue);
+            {% if column.credentials is not empty and column.credentials is not same as('AdmingenAllowed') %}
+              }
+            {% endif %}
+            // Inc is outside of the credentials check to be sync with headers.
+            // Otherwise if column X is authorized but depending on object, there will
+            // be some offset. Putting inc outise of the check will always update it.
+            $colNum++;
+          {% endfor %}
+
+          $row++;
+      }
+  }
+
+  protected function getSpreadsheetFileType{{ keyname|classify|php_name }}()
+  {
+      return '{{ builder.filetype(keyname) }}';
+  }
+
+  protected function getSpreadsheetFileName{{ keyname|classify|php_name }}($fileType)
+  {
+      return $this->fixExtension('{{ builder.filename(keyname) }}', $fileType);
+  }
+
+
+{% endfor %}
 
     protected function getExcelMimeType($fileType)
     {

--- a/UPGRADE.MD
+++ b/UPGRADE.MD
@@ -8,8 +8,16 @@ This page contains all upgrade notes since the release of the stable 2.0.0 versi
 
 ## Current `master` branch
 
+- Added support for PHPSpreadsheet due to the abandonment of PHPExcel
+
+## 2.4.0
+
 - In order to keep form label translation behavior consistent, filter form labels are no longer translated. This can be achieved by performing this translation in the project, which was already needed for new and edit form labels.
+
+## 2.3.0
 - Form type service names will be generated based on form FQCN instead of model FQCN. Old naming is aliased to new service name to not have BC break.
+
+## 2.2.0
 - Fixed [#285](https://github.com/symfony2admingenerator/GeneratorBundle/issues/285): added cookbook entry regarding injection
   of additional services in form types. Documented method of registration of auto generated form types in service container.
 - Fixed [#288](https://github.com/symfony2admingenerator/GeneratorBundle/issues/288): generated form types now have unique 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "suggest": {
         "symfony2admingenerator/form-extensions-bundle": "Symfony2 form extensions",
         "symfony2admingenerator/user-bundle": "FOSUserBundle integration for Admingenerator",
-        "liuggio/excelbundle": "(version ^2.0) Allows the usage of the Excel export.",
+        "phpoffice/phpspreadsheet": "Allows the usage of the Excel export.",
         "jms/security-extra-bundle": "Take advantages of JMS Security Extra Bundle in your generated templates.",
         "cnerta/breadcrumb-bundle": "(version ^2.0) Allows the usage of breadcrumbs.",
         "knplabs/knp-menu-bundle": "(version >1.0,<2.2) Allows automatic rendering of the menu structure."


### PR DESCRIPTION
As stated on https://github.com/PHPOffice/PHPExcel, PHPExcel is successed by PHPSpreadsheet.
This PR contains all the needed changes to support PHPSpreadsheet.
Previous code is still contained, so no BC is lost.
In order to use it, just replace `liuggio/excelbundle` by `phpoffice/phpspreadsheet` in your `composer.json`.