### PR TITLE
Prevent 404 when requesting an out of range page

### DIFF
--- a/Resources/views/templates/CommonAdmin/ListAction/pager.php.twig
+++ b/Resources/views/templates/CommonAdmin/ListAction/pager.php.twig
@@ -71,6 +71,7 @@
     protected function getPager()
     {
         $paginator = new Pagerfanta(new PagerAdapter($this->getQuery()));
+        $paginator->setNormalizeOutOfRangePages(true);
         $paginator->setMaxPerPage($this->getPerPage());
         $paginator->setCurrentPage($this->getPage(), false, true);
 


### PR DESCRIPTION
This will allow PagerFanta to normalize the requested page if for whatever reason the page no longer exists in the admin list, for example after a bulk delete action on the last page.